### PR TITLE
공통 코드 구현 (API 응답, 예외 처리)

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
@@ -1,0 +1,20 @@
+package com.devtraces.arterest.common.exception;
+
+import lombok.*;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class BaseException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	// 의도적인 예외이므로 stack trace 제거 (불필요한 예외처리 비용 제거)
+	@Override
+	public synchronized Throwable fillInStackTrace() {
+		return this;
+	}
+
+	public HttpStatus getHttpStatus() {
+		return errorCode.getHttpStatus();
+	}
+}

--- a/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
@@ -1,0 +1,14 @@
+package com.devtraces.arterest.common.exception;
+
+import lombok.*;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "예상치 못한 서버 에러가 발생했습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/devtraces/arterest/common/exception/ErrorController.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/ErrorController.java
@@ -1,0 +1,25 @@
+package com.devtraces.arterest.common.exception;
+
+import com.devtraces.arterest.common.response.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestControllerAdvice(annotations = RestController.class)
+public class ErrorController {
+
+	@ExceptionHandler(BaseException.class)
+	protected ResponseEntity<ApiErrorResponse<?>> handleBaseException(BaseException e) {
+		return ResponseEntity
+			.status(e.getHttpStatus())
+			.body(ApiErrorResponse.from(e.getErrorCode()));
+	}
+
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(RuntimeException.class)
+	protected ApiErrorResponse<?> handleRuntimeException(RuntimeException e) {
+		log.error(e.getMessage());
+		return ApiErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR);
+	}
+}

--- a/src/main/java/com/devtraces/arterest/common/response/ApiErrorResponse.java
+++ b/src/main/java/com/devtraces/arterest/common/response/ApiErrorResponse.java
@@ -13,15 +13,6 @@ public class ApiErrorResponse<T> {
 	private String code;
 	@JsonProperty("errorMessage")
 	private String message;
-	private T data;	// TODO: Exception에 Generic(T)를 전달할 방법을 찾지 못함
-
-	public static <T> ApiErrorResponse<T> from(ErrorCode errorCode, T data) {
-		return ApiErrorResponse.<T>builder()
-			.code(errorCode.getCode())
-			.message(errorCode.getMessage())
-			.data(data)
-			.build();
-	}
 
 	public static ApiErrorResponse<?> from(ErrorCode errorCode) {
 		return ApiErrorResponse.builder()

--- a/src/main/java/com/devtraces/arterest/common/response/ApiErrorResponse.java
+++ b/src/main/java/com/devtraces/arterest/common/response/ApiErrorResponse.java
@@ -1,0 +1,32 @@
+package com.devtraces.arterest.common.response;
+
+import com.devtraces.arterest.common.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiErrorResponse<T> {
+	@JsonProperty("errorCode")
+	private String code;
+	@JsonProperty("errorMessage")
+	private String message;
+	private T data;	// TODO: Exception에 Generic(T)를 전달할 방법을 찾지 못함
+
+	public static <T> ApiErrorResponse<T> from(ErrorCode errorCode, T data) {
+		return ApiErrorResponse.<T>builder()
+			.code(errorCode.getCode())
+			.message(errorCode.getMessage())
+			.data(data)
+			.build();
+	}
+
+	public static ApiErrorResponse<?> from(ErrorCode errorCode) {
+		return ApiErrorResponse.builder()
+			.code(errorCode.getCode())
+			.message(errorCode.getMessage())
+			.build();
+	}
+}

--- a/src/main/java/com/devtraces/arterest/common/response/ApiSuccessResponse.java
+++ b/src/main/java/com/devtraces/arterest/common/response/ApiSuccessResponse.java
@@ -1,0 +1,19 @@
+package com.devtraces.arterest.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiSuccessResponse<T> {
+	public static final ApiSuccessResponse<?> NO_DATA_RESPONSE = new ApiSuccessResponse<>();
+
+	private T data;
+
+	public static <T> ApiSuccessResponse<T> from(T data) {
+		return new ApiSuccessResponse<>(data);
+	}
+}


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #1

## 📍 특이사항
- 프로젝트를 실행시키기 위해서 DB 관련 프로퍼티가 필요하지만, 아직 팀 DB가 없어서 커밋하지 않았습니다. 개인적으로 설정해주세요!
- ~~예외를 발생시킬 때 제네릭(T)을 전달할 방법을 찾지 못했습니다. 방법이 없다면 에러 응답에서 data 필드를 빼야 할 것 같습니다.~~ -> data 필드 제거하는 것으로 결정.

## 📍 테스트
- [ ] API Test
- [ ] 단위 테스트
