### PR TITLE
비밀번호 확인 API 구현

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/user/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/AuthController.java
@@ -8,6 +8,8 @@ import com.devtraces.arterest.common.response.ApiSuccessResponse;
 import com.devtraces.arterest.controller.user.dto.MailAuthKeyCheckRequest;
 import com.devtraces.arterest.controller.user.dto.MailAuthKeyCheckResponse;
 import com.devtraces.arterest.controller.user.dto.MailAuthKeyRequest;
+import com.devtraces.arterest.controller.user.dto.PasswordCheckRequest;
+import com.devtraces.arterest.controller.user.dto.PasswordCheckResponse;
 import com.devtraces.arterest.controller.user.dto.SignInRequest;
 import com.devtraces.arterest.service.user.AuthService;
 import javax.validation.Valid;
@@ -61,5 +63,11 @@ public class AuthController {
 		String accessToken = bearerToken.substring(TOKEN_PREFIX.length() + 1);
 		authService.signOut(userId, accessToken);
 		return ApiSuccessResponse.NO_DATA_RESPONSE;
+	}
+
+	@PostMapping("/password/check")
+	public ApiSuccessResponse<PasswordCheckResponse> checkPassword(@AuthenticationPrincipal long userId, @RequestBody @Valid PasswordCheckRequest request) {
+		boolean isCorrect = authService.checkPassword(userId, request.getPassword());
+		return ApiSuccessResponse.from(PasswordCheckResponse.builder().isCorrect(isCorrect).build());
 	}
 }

--- a/src/main/java/com/devtraces/arterest/controller/user/dto/PasswordCheckRequest.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/dto/PasswordCheckRequest.java
@@ -1,0 +1,17 @@
+package com.devtraces.arterest.controller.user.dto;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PasswordCheckRequest {
+
+	@NotBlank(message = "비밀번호 입력은 필수입니다.")
+	private String password;
+
+}

--- a/src/main/java/com/devtraces/arterest/controller/user/dto/PasswordCheckResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/dto/PasswordCheckResponse.java
@@ -1,0 +1,17 @@
+package com.devtraces.arterest.controller.user.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PasswordCheckResponse {
+
+	private boolean isCorrect;
+
+}

--- a/src/main/java/com/devtraces/arterest/service/user/AuthService.java
+++ b/src/main/java/com/devtraces/arterest/service/user/AuthService.java
@@ -5,7 +5,6 @@ import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.jwt.JwtProvider;
 import com.devtraces.arterest.common.jwt.dto.TokenDto;
 import com.devtraces.arterest.common.redis.service.RedisService;
-import com.devtraces.arterest.controller.user.dto.MailAuthKeyCheckResponse;
 import com.devtraces.arterest.domain.user.User;
 import com.devtraces.arterest.domain.user.UserRepository;
 import java.util.Date;
@@ -91,5 +90,11 @@ public class AuthService {
 		// Access Token을 무효화시킬 수 없으므로 Redis에 블랙리스트 작성
 		Date expiredDate = jwtProvider.getExpiredDate(accessToken);
 		redisService.setAccessTokenBlackListValue(accessToken, userId, expiredDate);
+	}
+
+	public boolean checkPassword(long userId, String password) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> BaseException.USER_NOT_FOUND);
+		return passwordEncoder.matches(password, user.getPassword());
 	}
 }

--- a/src/test/java/com/devtraces/arterest/service/user/AuthServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/user/AuthServiceTest.java
@@ -164,4 +164,51 @@ class AuthServiceTest {
 
 		assertEquals(BaseException.WRONG_EMAIL_OR_PASSWORD, exception);
 	}
+
+	@Test
+	void testCheckPasswordByCorrectPassword() {
+		User mockUser = User.builder()
+			.id(1L)
+			.email("email@gmail.com")
+			.password("encodingPassword")
+			.build();
+		given(userRepository.findById(anyLong()))
+			.willReturn(Optional.of(mockUser));
+		given(passwordEncoder.matches(anyString(), anyString()))
+			.willReturn(true);
+
+		boolean isCorrect = authService.checkPassword(1L, "password");
+
+		assertTrue(isCorrect);
+	}
+
+	@Test
+	void testCheckPasswordByWrongPassword() {
+		User mockUser = User.builder()
+			.id(1L)
+			.email("email@gmail.com")
+			.password("encodingPassword")
+			.build();
+		given(userRepository.findById(anyLong()))
+			.willReturn(Optional.of(mockUser));
+		given(passwordEncoder.matches(anyString(), anyString()))
+			.willReturn(false);
+
+		boolean isCorrect = authService.checkPassword(1L, "wrong-password");
+
+		assertFalse(isCorrect);
+	}
+
+	// Optional이므로 null인 경우에 대한 예외를 처리했지만,
+	// userId는 인증인가를 하여 얻은 값이므로 이 예외가 발생할 가능성은 0%다.
+	@Test
+	void testCheckPasswordByWrongUserId() {
+		given(userRepository.findById(anyLong()))
+			.willReturn(Optional.empty());
+
+		BaseException exception = assertThrows(BaseException.class,
+			() -> authService.checkPassword(0L, "password"));
+
+		assertEquals(BaseException.USER_NOT_FOUND, exception);
+	}
 }


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #27

## 📍 특이사항
- 비밀번호 일치 API를 구현하고 Service 테스트 코드를 작성하였습니다.
  
## 📍 테스트
- [x] API Test
- [x] 단위 테스트
