### PR TITLE
feat: S3Util에 파일 삭제 기능 추가 (#31)

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/component/S3Util.java
+++ b/src/main/java/com/devtraces/arterest/common/component/S3Util.java
@@ -1,5 +1,6 @@
 package com.devtraces.arterest.common.component;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -7,19 +8,23 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.devtraces.arterest.common.exception.BaseException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
-public class S3Uploader {
+public class S3Util {
 
 	private static final Set<String> AVAILABLE_IMAGE_EXTENSION = new HashSet<>(Arrays.asList("gif", "png", "jpeg", "bmp", "webp"));
 
@@ -39,13 +44,27 @@ public class S3Uploader {
 			objectMetadata.setContentLength(inputStream.available());
 			objectMetadata.setContentType(multipartFile.getContentType());
 
-			amazonS3.putObject(new PutObjectRequest(bucket, s3FileName, inputStream, objectMetadata)
-				.withCannedAcl(CannedAccessControlList.PublicRead));
+			amazonS3.putObject(
+				new PutObjectRequest(bucket, s3FileName, inputStream, objectMetadata)
+					.withCannedAcl(CannedAccessControlList.PublicRead));
 		} catch (IOException e) {
+			log.error(e.getMessage());
 			throw BaseException.FAILED_FILE_UPLOAD;
 		}
 
 		return amazonS3.getUrl(bucket, s3FileName).toString();
+	}
+
+	public void deleteImage(String imageUrl) {
+		try {
+			String decodingUrl = URLDecoder.decode(imageUrl, "UTF-8");	// URL 디코딩
+			int startIdx = decodingUrl.indexOf(directory);	// directory 경로가 처음 나온 부분부터 Object Key에 해당
+			String objectKey = decodingUrl.substring(startIdx);
+			amazonS3.deleteObject(bucket, objectKey);
+		} catch (UnsupportedEncodingException | AmazonServiceException e) {
+			log.error(e.getMessage());
+			throw BaseException.INTERNAL_SERVER_ERROR;
+		}
 	}
 
 	private void validateImageFileName(String fileName) {

--- a/src/main/java/com/devtraces/arterest/common/component/S3Util.java
+++ b/src/main/java/com/devtraces/arterest/common/component/S3Util.java
@@ -26,7 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Component
 public class S3Util {
 
-	private static final Set<String> AVAILABLE_IMAGE_EXTENSION = new HashSet<>(Arrays.asList("gif", "png", "jpeg", "bmp", "webp"));
+	private static final Set<String> AVAILABLE_IMAGE_EXTENSION = new HashSet<>(Arrays.asList("gif", "png", "jpg", "jpeg", "bmp", "webp"));
 
 	private final AmazonS3 amazonS3;
 

--- a/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
@@ -15,11 +15,12 @@ public class BaseException extends RuntimeException {
 	public static final BaseException USER_INFO_NOT_MATCH = new BaseException(ErrorCode.USER_INFO_NOT_MATCH);
 	public static final BaseException WRONG_EMAIL_OR_PASSWORD = new BaseException(ErrorCode.WRONG_EMAIL_OR_PASSWORD);
 	public static final BaseException NOT_EXPIRED_ACCESS_TOKEN = new BaseException(ErrorCode.NOT_EXPIRED_ACCESS_TOKEN);
-  public static final BaseException INVALID_IMAGE_EXTENSION = new BaseException(ErrorCode.INVALID_IMAGE_EXTENSION);
+  	public static final BaseException INVALID_IMAGE_EXTENSION = new BaseException(ErrorCode.INVALID_IMAGE_EXTENSION);
 	public static final BaseException INVALID_TOKEN = new BaseException(ErrorCode.INVALID_TOKEN);
 	public static final BaseException FORBIDDEN = new BaseException(ErrorCode.FORBIDDEN);
 	public static final BaseException EXPIRED_OR_PREVIOUS_REFRESH_TOKEN = new BaseException(ErrorCode.EXPIRED_OR_PREVIOUS_REFRESH_TOKEN);
 	public static final BaseException USER_NOT_FOUND = new BaseException(ErrorCode.USER_NOT_FOUND);
+	public static final BaseException INTERNAL_SERVER_ERROR = new BaseException(ErrorCode.INTERNAL_SERVER_ERROR);
 	public static final BaseException FAILED_FILE_UPLOAD = new BaseException(ErrorCode.FAILED_FILE_UPLOAD);
 	public static final BaseException FAILED_SEND_EMAIL = new BaseException(ErrorCode.FAILED_SEND_EMAIL);
 

--- a/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
@@ -13,9 +13,9 @@ public enum ErrorCode {
 	WRONG_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "WRONG_EMAIL_OR_PASSWORD", "잘못된 이메일 혹은 비밀번호입니다."),
 	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
 	NOT_EXPIRED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "NOT_EXPIRED_ACCESS_TOKEN", "만료되지 않은 Access Token입니다. 비정상적인 시도이므로 로그아웃됩니다."),
-  INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "INVALID_IMAGE_EXTENSION", "처리할 수 없는 이미지 형식입니다."),
-  CONTENT_LIMIT_EXCEED(HttpStatus.BAD_REQUEST,"CONTENT_LIMIT_EXCEED","1000자를 초과하여 입력할 수 없습니다."),
-  USER_INFO_NOT_MATCH(HttpStatus.BAD_REQUEST,"USER_INFO_NOT_MATCH","작성자만 내용을 수정할 수 있습니다."),
+  	INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "INVALID_IMAGE_EXTENSION", "처리할 수 없는 이미지 형식입니다."),
+  	CONTENT_LIMIT_EXCEED(HttpStatus.BAD_REQUEST,"CONTENT_LIMIT_EXCEED","1000자를 초과하여 입력할 수 없습니다."),
+  	USER_INFO_NOT_MATCH(HttpStatus.BAD_REQUEST,"USER_INFO_NOT_MATCH","작성자만 내용을 수정할 수 있습니다."),
   
 	/* 401 */
 	ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "ACCESS_DENIED", "유효한 인증 정보가 부족합니다."),
@@ -27,13 +27,13 @@ public enum ErrorCode {
 
 	/* 404 */
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "존재하지 않는 유저입니다."),
-  FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "FEED_NOT_FOUND", "존재하지 않는 게시물입니다."),
-  REPLY_NOT_FOUND(HttpStatus.BAD_REQUEST, "REPLY_NOT_FOUND", "존재하지 않는 댓글입니다."),
-  REREPLY_NOT_FOUND(HttpStatus.BAD_REQUEST, "REREPLY_NOT_FOUND", "존재하지 않는 대댓글입니다."),
+  	FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "FEED_NOT_FOUND", "존재하지 않는 게시물입니다."),
+  	REPLY_NOT_FOUND(HttpStatus.BAD_REQUEST, "REPLY_NOT_FOUND", "존재하지 않는 댓글입니다."),
+  	REREPLY_NOT_FOUND(HttpStatus.BAD_REQUEST, "REREPLY_NOT_FOUND", "존재하지 않는 대댓글입니다."),
 
 	/* 500 */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "예상치 못한 서버 에러가 발생했습니다."),
-  FAILED_FILE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_FILE_UPLOAD", "파일 업로드에 실패했습니다."),
+  	FAILED_FILE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_FILE_UPLOAD", "파일 업로드에 실패했습니다."),
 	FAILED_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_SEND_EMAIL", "메일 전송에 실패했습니다.");
 
 	private final HttpStatus httpStatus;


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #31 

## 📍 특이사항
- S3 파일 업로더 외에 S3 파일 삭제 기능도 필요하여 S3Util이라는 통합 클래스로 변경하고 삭제 메서드를 추가하였습니다.
- 삭제를 위해선 Object Key가 필요한데, 이는 url에서 서버에서 설정한 directory 경로를 통해 추출하였습니다.
- 클래스 이름이 변경되었기 때문에 이전 명칭(S3Uploader)을 사용한 코드는 수정 부탁드립니다!
- 삭제 메서드를 사용하실 때엔 deleteImage(String imageUrl) 메서드를 호출해주시면 됩니다. :)

## 📍 테스트
- [ ] API Test
- [ ] 단위 테스트
