### PR TITLE
Access token 및 Refresh token 전송 방식 변경

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
@@ -15,6 +15,7 @@ import java.security.Key;
 import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -68,7 +69,16 @@ public class JwtProvider {
 
 		return TokenDto.builder()
 			.accessToken(accessToken)
-			.refreshToken(refreshToken)
+			.responseCookie(generateCookie(refreshToken))
+			.build();
+	}
+
+	private ResponseCookie generateCookie(String refreshToken) {
+		return ResponseCookie.from("refreshToken", refreshToken)
+			.httpOnly(true)
+			.secure(true)
+			.sameSite("None")
+			.path("/refresh-token")
 			.build();
 	}
 

--- a/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
@@ -2,17 +2,22 @@ package com.devtraces.arterest.common.jwt.controller;
 
 import static com.devtraces.arterest.common.jwt.JwtProperties.AUTHORIZATION_HEADER;
 import static com.devtraces.arterest.common.jwt.JwtProperties.TOKEN_PREFIX;
+import static com.devtraces.arterest.controller.user.AuthController.ACCESS_TOKEN_PREFIX;
+import static com.devtraces.arterest.controller.user.AuthController.SET_COOKIE;
 
 import com.devtraces.arterest.common.jwt.dto.ReissueRequest;
 import com.devtraces.arterest.common.jwt.dto.TokenDto;
 import com.devtraces.arterest.common.jwt.service.JwtService;
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
+import java.util.HashMap;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,18 +27,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class JwtController {
 
 	private final JwtService jwtService;
-	public static final String SET_COOKIE = "Set-Cookie";
 
 	@PostMapping("/reissue")
-	public ResponseEntity<?> reissue(@RequestBody @Valid ReissueRequest request) {
+	public ResponseEntity<ApiSuccessResponse<?>> reissue(
+		@RequestBody @Valid ReissueRequest request,
+		@RequestHeader("accessToken") String accessToken,
+		@CookieValue("refreshToken") String refreshToken) {
 		TokenDto tokenDto = jwtService.reissue(
 			request.getNickname(),
-			request.getAccessToken(),
-			request.getRefreshToken());
+			accessToken,
+			refreshToken);
 
 		return ResponseEntity.ok()
 			.header(SET_COOKIE, tokenDto.getResponseCookie().toString())
-			.body(tokenDto.getAccessToken());
+			.body(ApiSuccessResponse.from(new HashMap(){{
+				put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + tokenDto.getAccessToken());
+			}}));
 	}
-
 }

--- a/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
@@ -22,23 +22,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class JwtController {
 
 	private final JwtService jwtService;
+	public static final String SET_COOKIE = "Set-Cookie";
 
 	@PostMapping("/reissue")
-	public ResponseEntity<ApiSuccessResponse<?>> reissue(@RequestBody @Valid ReissueRequest request) {
+	public ResponseEntity<?> reissue(@RequestBody @Valid ReissueRequest request) {
 		TokenDto tokenDto = jwtService.reissue(
 			request.getNickname(),
 			request.getAccessToken(),
 			request.getRefreshToken());
 
-		HttpHeaders httpHeaders = new HttpHeaders();
-		httpHeaders.add(AUTHORIZATION_HEADER,
-			TOKEN_PREFIX + " " + tokenDto.getAccessToken());
-		httpHeaders.add("X-REFRESH-TOKEN", tokenDto.getRefreshToken());
-
-		return ResponseEntity
-			.ok()
-			.headers(httpHeaders)
-			.body(ApiSuccessResponse.NO_DATA_RESPONSE);
+		return ResponseEntity.ok()
+			.header(SET_COOKIE, tokenDto.getResponseCookie().toString())
+			.body(tokenDto.getAccessToken());
 	}
 
 }

--- a/src/main/java/com/devtraces/arterest/common/jwt/dto/ReissueRequest.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/dto/ReissueRequest.java
@@ -13,10 +13,4 @@ public class ReissueRequest {
 
 	@NotBlank(message = "닉네임 입력은 필수입니다.")
 	private String nickname;
-
-	@NotBlank(message = "Access Token 입력은 필수입니다.")
-	private String accessToken;
-
-	@NotBlank(message = "Refresh Token 입력은 필수입니다.")
-	private String refreshToken;
 }

--- a/src/main/java/com/devtraces/arterest/common/jwt/dto/TokenDto.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/dto/TokenDto.java
@@ -3,6 +3,7 @@ package com.devtraces.arterest.common.jwt.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.ResponseCookie;
 
 @Getter
 @Builder
@@ -10,6 +11,6 @@ import lombok.Getter;
 public class TokenDto {
 
 	private String accessToken;
-	private String refreshToken;
+	private ResponseCookie responseCookie;
 
 }

--- a/src/main/java/com/devtraces/arterest/controller/user/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/AuthController.java
@@ -14,6 +14,7 @@ import com.devtraces.arterest.controller.user.dto.SignInRequest;
 import com.devtraces.arterest.controller.user.dto.UserRegistrationRequest;
 import com.devtraces.arterest.controller.user.dto.UserRegistrationResponse;
 import com.devtraces.arterest.service.user.AuthService;
+import java.util.HashMap;
 import javax.servlet.http.Cookie;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 	private final AuthService authService;
 	public static final String SET_COOKIE = "Set-Cookie";
+	public static final String ACCESS_TOKEN_PREFIX = "accessToken";
 
 	@PostMapping("sign-up")
 	public ApiSuccessResponse<UserRegistrationResponse> signUp(@ModelAttribute @Valid UserRegistrationRequest request) {
@@ -53,13 +55,15 @@ public class AuthController {
 	}
 
 	@PostMapping("/sign-in")
-	public ResponseEntity<?> signIn(@RequestBody @Valid SignInRequest request) {
+	public ResponseEntity<ApiSuccessResponse<?>> signIn(@RequestBody @Valid SignInRequest request) {
 		TokenDto tokenDto = authService.signInAndGenerateJwtToken(request.getEmail(),
 			request.getPassword());
 
 		return ResponseEntity.ok()
-			.header(SET_COOKIE, tokenDto.getResponseCookie().toString())
-			.body(tokenDto.getAccessToken());
+				.header(SET_COOKIE, tokenDto.getResponseCookie().toString())
+				.body(ApiSuccessResponse.from(new HashMap(){{
+					put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + tokenDto.getAccessToken());
+				}}));
 	}
 
 	@PostMapping("/sign-out")

--- a/src/main/java/com/devtraces/arterest/controller/user/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/AuthController.java
@@ -14,6 +14,7 @@ import com.devtraces.arterest.controller.user.dto.SignInRequest;
 import com.devtraces.arterest.controller.user.dto.UserRegistrationRequest;
 import com.devtraces.arterest.controller.user.dto.UserRegistrationResponse;
 import com.devtraces.arterest.service.user.AuthService;
+import javax.servlet.http.Cookie;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthController {
 	private final AuthService authService;
+	public static final String SET_COOKIE = "Set-Cookie";
 
 	@PostMapping("sign-up")
 	public ApiSuccessResponse<UserRegistrationResponse> signUp(@ModelAttribute @Valid UserRegistrationRequest request) {
@@ -51,19 +53,13 @@ public class AuthController {
 	}
 
 	@PostMapping("/sign-in")
-	public ResponseEntity<ApiSuccessResponse<?>> signIn(@RequestBody @Valid SignInRequest request) {
+	public ResponseEntity<?> signIn(@RequestBody @Valid SignInRequest request) {
 		TokenDto tokenDto = authService.signInAndGenerateJwtToken(request.getEmail(),
 			request.getPassword());
 
-		HttpHeaders httpHeaders = new HttpHeaders();
-		httpHeaders.add(AUTHORIZATION_HEADER,
-			TOKEN_PREFIX + " " + tokenDto.getAccessToken());
-		httpHeaders.add("X-REFRESH-TOKEN", tokenDto.getRefreshToken());
-
-		return ResponseEntity
-			.ok()
-			.headers(httpHeaders)
-			.body(ApiSuccessResponse.NO_DATA_RESPONSE);
+		return ResponseEntity.ok()
+			.header(SET_COOKIE, tokenDto.getResponseCookie().toString())
+			.body(tokenDto.getAccessToken());
 	}
 
 	@PostMapping("/sign-out")

--- a/src/main/java/com/devtraces/arterest/controller/user/OauthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/OauthController.java
@@ -5,6 +5,7 @@ import com.devtraces.arterest.common.response.ApiSuccessResponse;
 import com.devtraces.arterest.controller.user.dto.OauthKakaoSignInRequest;
 import com.devtraces.arterest.service.user.AuthService;
 import com.devtraces.arterest.service.user.OauthService;
+import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static com.devtraces.arterest.common.jwt.JwtProperties.AUTHORIZATION_HEADER;
 import static com.devtraces.arterest.common.jwt.JwtProperties.TOKEN_PREFIX;
+import static com.devtraces.arterest.controller.user.AuthController.ACCESS_TOKEN_PREFIX;
+import static com.devtraces.arterest.controller.user.AuthController.SET_COOKIE;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,14 +26,14 @@ public class OauthController {
 
     private final OauthService oauthService;
 
-    public static final String SET_COOKIE = "Set-Cookie";
-
     @PostMapping("/kakao/callback")
-    public ResponseEntity<?> oauthKakaoSignIn(@RequestBody OauthKakaoSignInRequest request) {
+    public ResponseEntity<ApiSuccessResponse<?>> oauthKakaoSignIn(@RequestBody OauthKakaoSignInRequest request) {
         TokenDto tokenDto = oauthService.oauthKakaoSignIn(request.getAccessToken());
 
         return ResponseEntity.ok()
             .header(SET_COOKIE, tokenDto.getResponseCookie().toString())
-            .body(tokenDto.getAccessToken());
+            .body(ApiSuccessResponse.from(new HashMap(){{
+                put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + tokenDto.getAccessToken());
+            }}));
     }
 }

--- a/src/main/java/com/devtraces/arterest/controller/user/OauthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/OauthController.java
@@ -23,18 +23,14 @@ public class OauthController {
 
     private final OauthService oauthService;
 
+    public static final String SET_COOKIE = "Set-Cookie";
+
     @PostMapping("/kakao/callback")
-    public ResponseEntity<ApiSuccessResponse<?>> oauthKakaoSignIn(@RequestBody OauthKakaoSignInRequest request) {
+    public ResponseEntity<?> oauthKakaoSignIn(@RequestBody OauthKakaoSignInRequest request) {
         TokenDto tokenDto = oauthService.oauthKakaoSignIn(request.getAccessToken());
 
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.add(AUTHORIZATION_HEADER,
-                TOKEN_PREFIX + " " + tokenDto.getAccessToken());
-        httpHeaders.add("X-REFRESH-TOKEN", tokenDto.getRefreshToken());
-
-        return ResponseEntity
-                .ok()
-                .headers(httpHeaders)
-                .body(ApiSuccessResponse.NO_DATA_RESPONSE);
+        return ResponseEntity.ok()
+            .header(SET_COOKIE, tokenDto.getResponseCookie().toString())
+            .body(tokenDto.getAccessToken());
     }
 }


### PR DESCRIPTION
## 📍 관련 이슈
- 로그인시 Access token 과 Refresh token 전송 방식을 변경함.

## 📍 특이사항
- Access token 의 경우 body 로 전송하고, Refresh token 의 경우 httpOnly secure 방식으로 쿠키에 담아 전송함.
- Access token, Refresh token 을 서버 측에서 받는 경우, Access token 을 Header 로, Refresh token 은 쿠키로 받음.

## 📍 테스트
- [x] API Test
