### PR TITLE
로그인 성공시 응답에 nickname도 포함하게 수정

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
@@ -11,6 +11,8 @@ import com.devtraces.arterest.common.jwt.service.JwtService;
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
 import java.util.HashMap;
 import javax.validation.Valid;
+
+import com.devtraces.arterest.service.user.dto.TokenWithNicknameDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -32,14 +34,14 @@ public class JwtController {
 	public ResponseEntity<ApiSuccessResponse<?>> reissue(
 		@RequestHeader("accessToken") String accessToken,
 		@CookieValue("refreshToken") String refreshToken) {
-		TokenDto tokenDto = jwtService.reissue(
-			accessToken,
-			refreshToken);
+		TokenWithNicknameDto dto = jwtService.reissue(accessToken, refreshToken);
+
+		HashMap hashMap = new HashMap();
+		hashMap.put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + dto.getAccessToken());
+		hashMap.put("nickname", dto.getNickname());
 
 		return ResponseEntity.ok()
-			.header(SET_COOKIE, tokenDto.getResponseCookie().toString())
-			.body(ApiSuccessResponse.from(new HashMap(){{
-				put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + tokenDto.getAccessToken());
-			}}));
+			.header(SET_COOKIE, dto.getResponseCookie().toString())
+			.body(ApiSuccessResponse.from(hashMap));
 	}
 }

--- a/src/main/java/com/devtraces/arterest/controller/user/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/AuthController.java
@@ -17,6 +17,8 @@ import com.devtraces.arterest.service.user.AuthService;
 import java.util.HashMap;
 import javax.servlet.http.Cookie;
 import javax.validation.Valid;
+
+import com.devtraces.arterest.service.user.dto.TokenWithNicknameDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -56,14 +58,18 @@ public class AuthController {
 
 	@PostMapping("/sign-in")
 	public ResponseEntity<ApiSuccessResponse<?>> signIn(@RequestBody @Valid SignInRequest request) {
-		TokenDto tokenDto = authService.signInAndGenerateJwtToken(request.getEmail(),
-			request.getPassword());
+		TokenWithNicknameDto dto = authService.signInAndGenerateJwtToken(
+				request.getEmail(),
+				request.getPassword()
+		);
+
+		HashMap hashMap = new HashMap();
+		hashMap.put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + dto.getAccessToken());
+		hashMap.put("nickname", dto.getNickname());
 
 		return ResponseEntity.ok()
-				.header(SET_COOKIE, tokenDto.getResponseCookie().toString())
-				.body(ApiSuccessResponse.from(new HashMap(){{
-					put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + tokenDto.getAccessToken());
-				}}));
+				.header(SET_COOKIE, dto.getResponseCookie().toString())
+				.body(ApiSuccessResponse.from(hashMap));
 	}
 
 	@PostMapping("/sign-out")

--- a/src/main/java/com/devtraces/arterest/controller/user/OauthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/OauthController.java
@@ -6,6 +6,8 @@ import com.devtraces.arterest.controller.user.dto.OauthKakaoSignInRequest;
 import com.devtraces.arterest.service.user.AuthService;
 import com.devtraces.arterest.service.user.OauthService;
 import java.util.HashMap;
+
+import com.devtraces.arterest.service.user.dto.TokenWithNicknameDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -28,12 +30,15 @@ public class OauthController {
 
     @PostMapping("/kakao/callback")
     public ResponseEntity<ApiSuccessResponse<?>> oauthKakaoSignIn(@RequestBody OauthKakaoSignInRequest request) {
-        TokenDto tokenDto = oauthService.oauthKakaoSignIn(request.getAccessTokenFromKakao());
+        TokenWithNicknameDto dto =
+                oauthService.oauthKakaoSignIn(request.getAccessTokenFromKakao());
+
+        HashMap hashMap = new HashMap();
+        hashMap.put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + dto.getAccessToken());
+        hashMap.put("nickname", dto.getNickname());
 
         return ResponseEntity.ok()
-            .header(SET_COOKIE, tokenDto.getResponseCookie().toString())
-            .body(ApiSuccessResponse.from(new HashMap(){{
-                put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + tokenDto.getAccessToken());
-            }}));
+            .header(SET_COOKIE, dto.getResponseCookie().toString())
+            .body(ApiSuccessResponse.from(hashMap));
     }
 }

--- a/src/main/java/com/devtraces/arterest/service/user/AuthService.java
+++ b/src/main/java/com/devtraces/arterest/service/user/AuthService.java
@@ -16,6 +16,8 @@ import com.devtraces.arterest.model.user.UserRepository;
 import java.util.Date;
 
 import java.util.Random;
+
+import com.devtraces.arterest.service.user.dto.TokenWithNicknameDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -108,12 +110,15 @@ public class AuthService {
 	}
 
 	@Transactional(readOnly = true)
-	public TokenDto signInAndGenerateJwtToken(String email, String password) {
+	public TokenWithNicknameDto signInAndGenerateJwtToken(String email, String password) {
 		User user = userRepository.findByEmail(email)
 			.orElseThrow(() -> BaseException.WRONG_EMAIL_OR_PASSWORD);
 		validateLogin(user, password);
 
-		return jwtProvider.generateAccessTokenAndRefreshToken(user.getId());
+		TokenDto tokenDto =
+				jwtProvider.generateAccessTokenAndRefreshToken(user.getId());
+
+		return TokenWithNicknameDto.from(user.getNickname(), tokenDto);
 	}
 
 	private void validateLogin(User user, String passwordInput) {

--- a/src/main/java/com/devtraces/arterest/service/user/dto/TokenWithNicknameDto.java
+++ b/src/main/java/com/devtraces/arterest/service/user/dto/TokenWithNicknameDto.java
@@ -1,0 +1,26 @@
+package com.devtraces.arterest.service.user.dto;
+
+import com.devtraces.arterest.common.jwt.dto.TokenDto;
+import lombok.*;
+import org.springframework.http.ResponseCookie;
+
+import static com.devtraces.arterest.common.jwt.JwtProperties.TOKEN_PREFIX;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class TokenWithNicknameDto {
+
+    private String nickname;
+    private String accessToken;
+    private ResponseCookie responseCookie;
+
+    public static TokenWithNicknameDto from(String nickname, TokenDto tokenDto) {
+        return TokenWithNicknameDto.builder()
+                .nickname(nickname)
+                .accessToken(tokenDto.getAccessToken())
+                .responseCookie(tokenDto.getResponseCookie())
+                .build();
+    }
+}

--- a/src/test/java/com/devtraces/arterest/common/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/common/jwt/service/JwtServiceTest.java
@@ -11,6 +11,7 @@ import com.devtraces.arterest.common.jwt.JwtProvider;
 import com.devtraces.arterest.common.jwt.dto.TokenDto;
 import com.devtraces.arterest.common.redis.service.RedisService;
 import com.devtraces.arterest.service.user.AuthService;
+import com.devtraces.arterest.service.user.dto.TokenWithNicknameDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -48,10 +49,10 @@ class JwtServiceTest {
 		given(jwtProvider.generateAccessTokenAndRefreshToken(anyLong()))
 			.willReturn(mockTokenDto);
 
-		TokenDto tokenDto = jwtService.reissue( "access-token", "refresh-token");
+		TokenWithNicknameDto dto = jwtService.reissue("access-token", "refresh-token");
 
-		assertEquals("access-token2", tokenDto.getAccessToken());
-		assertEquals("refresh-token2", tokenDto.getResponseCookie().getValue());
+		assertEquals("access-token2", dto.getAccessToken());
+		assertEquals("refresh-token2", dto.getResponseCookie().getValue());
 	}
 
 	// 유효하지 않은 토큰인 경우


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #56 

## 📍 특이사항
* 로그인 성공시 accessToken과 nickname이 함께 응답할 수 있도록 로직을 수정했습니다. 

## 📍 테스트
- [x] API Test
- [ ] 단위 테스트
