### PR TITLE
카카오 소셜로그인시 username을 nickname과 같게 수정 

### DIFF
--- a/src/main/java/com/devtraces/arterest/service/user/OauthService.java
+++ b/src/main/java/com/devtraces/arterest/service/user/OauthService.java
@@ -127,7 +127,7 @@ public class OauthService {
         return UserInfoFromKakaoDto.builder()
                 .kakaoUserId(kakaoUserId)
                 .email(email)
-                .username("사용자 이름")
+                .username(nickname)
                 .nickname(nickname)
                 .profileImageUrl(profileImageUrl)
                 .description("나에 대한 설명을 추가해주세요!")


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #64 

## 📍 특이사항
* 카카오에서 사용자의 username을 받을 수 없어 해당 값이 null이 되는 문제를 해결하기 위해 초기 username 값은 nickname과 동일하게 설정했습니다. 
* 단위 테스트는 추후 리팩토링 후 진행하도록 하겠습니다. 

## 📍 테스트
- [ ] API Test
- [ ] 단위 테스트
