### PR TITLE
로그인시 Access Token 인증을 하지 않게 로직 수정

### DIFF
--- a/src/main/java/com/devtraces/arterest/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/devtraces/arterest/configuration/SecurityConfiguration.java
@@ -55,8 +55,13 @@ public class SecurityConfiguration {
 				UsernamePasswordAuthenticationFilter.class)
 
 			.authorizeRequests()
-			.antMatchers("/api/auth/sign-out", "api/auth/password/check").hasRole("USER")
-			.anyRequest().permitAll(); // permitAll() 로 하면 JwtAuthenticationEntryPoint 동작안함
+			.antMatchers("/api/auth/sign-up", "/api/auth/email/auth-key",
+				"/api/auth/email/auth-key/check", "/api/auth/sign-in",
+				"/api/oauth/kakao/callback", "/api/auth/password/check",
+				"/api/auth/sign-out", "/api/auth/withdrawal",
+				"/api/users/email/**", "/api/users/nickname/**",
+				"/api/users/password", "/api/tokens/reissue").permitAll()//.hasRole("USER")
+			.anyRequest().authenticated(); // permitAll() 로 하면 JwtAuthenticationEntryPoint 동작안함
 
 		return http.build();
 	}


### PR DESCRIPTION
## 📍 관련 이슈
- 로그인시 Access Token 을 보내주지 않음에도 JwtAuthenticationEntryPoint 를 타는 현상

## 📍 특이사항
- security configuration 에 Access Token 인증없이 접근 가능한 url 목록 추가

## 📍 테스트
- [x] API Test
