### PR TITLE
Fix/69 feed update getlist refactoring

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/feed/FeedController.java
+++ b/src/main/java/com/devtraces/arterest/controller/feed/FeedController.java
@@ -57,7 +57,7 @@ public class FeedController {
         return ApiSuccessResponse.from(feedreadService.getOneFeed(userId, feedId));
     }
 
-    @PutMapping("/{feedId}")
+    @PostMapping("/{feedId}")
     public ApiSuccessResponse<FeedUpdateResponse> updateFeed(
         @AuthenticationPrincipal Long userId,
         @RequestParam("content") String content,

--- a/src/main/java/com/devtraces/arterest/controller/feed/FeedController.java
+++ b/src/main/java/com/devtraces/arterest/controller/feed/FeedController.java
@@ -44,10 +44,13 @@ public class FeedController {
     @GetMapping("/list/{nickname}")
     public ApiSuccessResponse<List<FeedResponse>> getFeedList(
         @AuthenticationPrincipal Long userId,
+        @PathVariable String nickname,
         @RequestParam int page,
         @RequestParam(required = false, defaultValue = "10") int pageSize
     ){
-        return ApiSuccessResponse.from(feedreadService.getFeedResponseList(userId, page, pageSize));
+        return ApiSuccessResponse.from(
+            feedreadService.getFeedResponseList(userId, nickname, page, pageSize)
+        );
     }
 
     @GetMapping("/{feedId}")

--- a/src/main/java/com/devtraces/arterest/model/likecache/LikeNumberCacheRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/likecache/LikeNumberCacheRepository.java
@@ -31,7 +31,16 @@ public class LikeNumberCacheRepository {
             String key = getKey(feedId);
             template.opsForValue().set(key, "0");
         } catch (Exception e){
-            log.error("캐시서버에서 좋아요 개수 저장 실패.");
+            log.error("캐시서버에서 좋아요 개수 0으로 저장 실패.");
+        }
+    }
+
+    public void setLikeNumber(Long feedId, Long likeNumber){
+        try {
+            String key = getKey(feedId);
+            template.opsForValue().set(key, String.valueOf(likeNumber));
+        } catch (Exception e){
+            log.error("캐시서버에 좋아요 개수 저장 실패");
         }
     }
 

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedReadService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedReadService.java
@@ -8,7 +8,6 @@ import com.devtraces.arterest.model.feed.FeedRepository;
 import com.devtraces.arterest.model.like.LikeRepository;
 import com.devtraces.arterest.model.like.Likes;
 import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
-import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
 import java.util.List;
 import java.util.Set;
@@ -32,26 +31,13 @@ public class FeedReadService {
 	public List<FeedResponse> getFeedResponseList(
 		Long userId, String nickname, int page, int pageSize
 	){
-		// 요청한 사용자가 좋아요를 누른 피드들의 주키 아이디 번호들을 먼저 불러온다.
-		Set<Long> likedFeedSet = likeRepository.findAllByUserId(userId)
-			.stream().map(Likes::getFeedId).collect(Collectors.toSet());
-
-		// 요청한 사용자가 북마크 했던 피드들의 주키 아이디 번호들도 불러온다.
-		Set<Long> bookmarkedFeedSet = bookmarkRepository.findAllByUserId(userId)
-			.stream().map(bookmark -> bookmark.getFeed().getId()).collect(Collectors.toSet());
-
+		Set<Long> likedFeedSet = getLikedFeedSet(userId);
+		Set<Long> bookmarkedFeedSet = getBookmarkedFeedSet(userId);
 		Long targetUserId = userRepository.findByNickname(nickname)
 			.orElseThrow(() -> BaseException.USER_NOT_FOUND).getId();
-
-		// 피드 별 좋아요 개수는 레디스를 먼저 보게 만들고, 그게 불가능 할때만 Like 테이블에서 찾도록 한다.
 		return feedRepository.findAllByUserId(targetUserId, PageRequest.of(page, pageSize)).stream().map(
 			feed -> {
-				Long likeNumber = likeNumberCacheRepository.getFeedLikeNumber(feed.getId());
-				if(likeNumber == null) {
-					likeNumber = likeRepository.countByFeedId(feed.getId());
-					// 현재 캐시서버에 좋아요 개수가 기록돼 있지 않으므로 다음 read 요쳥을 위해서 캐시해 둠.
-					likeNumberCacheRepository.setLikeNumber(feed.getId(), likeNumber);
-				}
+				Long likeNumber = getOrCacheLikeNumber(feed.getId(), feed);
 				return FeedResponse.from(feed, likedFeedSet, likeNumber, bookmarkedFeedSet);
 			}
 		).collect(Collectors.toList());
@@ -59,22 +45,35 @@ public class FeedReadService {
 
 	@Transactional(readOnly = true)
 	public FeedResponse getOneFeed(Long userId, Long feedId){
-		Set<Long> likedFeedSet = likeRepository.findAllByUserId(userId)
-			.stream().map(Likes::getFeedId).collect(Collectors.toSet());
-
-		Set<Long> bookmarkedFeedSet = bookmarkRepository.findAllByUserId(userId)
-			.stream().map(bookmark -> bookmark.getFeed().getId()).collect(Collectors.toSet());
-
+		Set<Long> likedFeedSet = getLikedFeedSet(userId);
+		Set<Long> bookmarkedFeedSet = getBookmarkedFeedSet(userId);
 		Feed feed = feedRepository.findById(feedId).orElseThrow(() -> BaseException.FEED_NOT_FOUND);
+		Long likeNumber = getOrCacheLikeNumber(feedId, feed);
 
+		return FeedResponse.from(
+			feed, likedFeedSet, likeNumber, bookmarkedFeedSet
+		);
+	}
+
+	// 피드 별 좋아요 개수는 레디스를 먼저 보게 만들고, 그게 불가능 할때만 Like 테이블에서 찾도록 한다.
+	private Long getOrCacheLikeNumber(Long feedId, Feed feed) {
 		Long likeNumber = likeNumberCacheRepository.getFeedLikeNumber(feedId);
 		if(likeNumber == null) {
 			likeNumber = likeRepository.countByFeedId(feedId);
 			likeNumberCacheRepository.setLikeNumber(feed.getId(), likeNumber);
 		}
+		return likeNumber;
+	}
 
-		return FeedResponse.from(
-			feed, likedFeedSet, likeNumber, bookmarkedFeedSet
-		);
+	// 요청한 사용자가 좋아요를 누른 피드들의 주키 아이디 번호들을 먼저 불러온다.
+	private Set<Long> getLikedFeedSet(Long userId) {
+		return likeRepository.findAllByUserId(userId)
+			.stream().map(Likes::getFeedId).collect(Collectors.toSet());
+	}
+
+	// 요청한 사용자가 북마크 했던 피드들의 주키 아이디 번호들도 불러온다.
+	private Set<Long> getBookmarkedFeedSet(Long userId) {
+		return bookmarkRepository.findAllByUserId(userId)
+			.stream().map(bookmark -> bookmark.getFeed().getId()).collect(Collectors.toSet());
 	}
 }

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedReadService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedReadService.java
@@ -50,7 +50,7 @@ public class FeedReadService {
 				if(likeNumber == null) {
 					likeNumber = likeRepository.countByFeedId(feed.getId());
 					// 현재 캐시서버에 좋아요 개수가 기록돼 있지 않으므로 다음 read 요쳥을 위해서 캐시해 둠.
-					likeNumberCacheRepository.setInitialLikeNumber(likeNumber);
+					likeNumberCacheRepository.setLikeNumber(feed.getId(), likeNumber);
 				}
 				return FeedResponse.from(feed, likedFeedSet, likeNumber, bookmarkedFeedSet);
 			}
@@ -70,7 +70,7 @@ public class FeedReadService {
 		Long likeNumber = likeNumberCacheRepository.getFeedLikeNumber(feedId);
 		if(likeNumber == null) {
 			likeNumber = likeRepository.countByFeedId(feedId);
-			likeNumberCacheRepository.setInitialLikeNumber(likeNumber);
+			likeNumberCacheRepository.setLikeNumber(feed.getId(), likeNumber);
 		}
 
 		return FeedResponse.from(

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
@@ -41,19 +41,13 @@ public class FeedService {
     ) {
         // 게시물 텍스트 없이 사진 또는 해시태그만 게시물로서 올리고 싶은 유저가 분명 있을 것이므로,
         // content가 빈 스트링인 것에 대해서도 받아들인다.
-        if(content.length() > CommonConstant.CONTENT_LENGTH_LIMIT){
-            throw BaseException.CONTENT_LIMIT_EXCEED;
-        }
-        if(hashtagList != null && hashtagList.size() > CommonConstant.HASHTAG_COUNT_LIMIT){
-            throw BaseException.HASHTAG_LIMIT_EXCEED;
-        }
+        validateContentAndHashtagList(content, hashtagList);
         if(imageFileList != null && imageFileList.size() > CommonConstant.IMAGE_FILE_COUNT_LIMIT){
             throw BaseException.IMAGE_FILE_COUNT_LIMIT_EXCEED;
         }
         User authorUser = userRepository.findById(userId).orElseThrow(
             () -> BaseException.USER_NOT_FOUND
         );
-
         // 유저가 올린 이미지가 없을 경우, imageUrlBuilder는 toString하면 "" 이렇게 빈 문자열 된다.
         StringBuilder imageUrlBuilder = new StringBuilder();
         if(imageFileList != null){
@@ -62,7 +56,6 @@ public class FeedService {
                 imageUrlBuilder.append(',');
             }
         }
-
         // 유저가 올린 이미지가 없을 경우, 최종적으로 프런트엔드가 받는 JSON에서는
         // "imageUrls" : null이 리턴된다.
         Feed newFeed = feedRepository.save(
@@ -72,7 +65,6 @@ public class FeedService {
                 .user(authorUser)
                 .build()
         );
-
         // 입력 받은 해시태그 값들을 순회하면서 새로 저장해야 하는 것은 저장하고, 이미 찾을 수 있는 것은 찾아내서
         // FeedHashtagMap에 저장한다.
         // FeedHashtagMap 엔티티를 빌드하기 위해서는 Feed 엔티티와 Hashtag 엔티티 모두가 필요하다.
@@ -93,11 +85,9 @@ public class FeedService {
                 );
             }
         }
-
         // 새로 만들어진 게시물이므로, 좋아요 개수를 레디스에 0으로 캐시 해둔다.
         // 레디스가 다운되어도 게시물 저장 로직 전체가 취소 및 롤백되지 않고 그대로 완료 된다.
         likeNumberCacheRepository.setInitialLikeNumber(newFeed.getId());
-
         return FeedCreateResponse.from(newFeed, 0L, hashtagList);
     }
 
@@ -109,16 +99,7 @@ public class FeedService {
         List<String> prevImageUrlList,
         Long feedId
     ) {
-        if(
-            content != null && content.length() > CommonConstant.CONTENT_LENGTH_LIMIT
-        ){
-            throw BaseException.CONTENT_LIMIT_EXCEED;
-        }
-        if(
-            hashtagList != null && hashtagList.size() > CommonConstant.HASHTAG_COUNT_LIMIT
-        ){
-            throw BaseException.HASHTAG_LIMIT_EXCEED;
-        }
+        validateContentAndHashtagList(content, hashtagList);
         if(
             imageFileList != null && prevImageUrlList != null &&
             imageFileList.size() + prevImageUrlList.size() > CommonConstant.IMAGE_FILE_COUNT_LIMIT
@@ -141,7 +122,6 @@ public class FeedService {
                 imagesToKeepSet.add( prevImageUrlInfo.split(",")[0] );
             }
         }
-
         // 기존에 S3에 저장돼 있던 사진들 중 위에서 정의한 셋에 포함돼 있지 않는 이미지들을 삭제한다.
         if(!feed.getImageUrls().equals("")){
             for(String deleteTargetUrl : feed.getImageUrls().split(",")){
@@ -150,20 +130,16 @@ public class FeedService {
                 }
             }
         }
-
         // String 배열을 만든 후, 기존 이미지 url들을 정해진 인덱스에 맞게 넣어 둔다.
         int newImageFileCount = imageFileList == null ? 0 : imageFileList.size();
         int existingImageUrlCount = prevImageUrlList == null ? 0 : prevImageUrlList.size();
-
         String[] resultImageUrlArr = new String[newImageFileCount + existingImageUrlCount];
-
         if(existingImageUrlCount != 0){
             for(String prevImageUrlInfo : prevImageUrlList){
                 String[] prevImageUrlInfoArr = prevImageUrlInfo.split(",");
                 resultImageUrlArr[Integer.parseInt(prevImageUrlInfoArr[1])] = prevImageUrlInfoArr[0];
             }
         }
-
         // 새로운 이미지들을 S3에 업로드 하면서 resultImageUrlArr의 null 인 칸들에 순서대로 넣어준다.
         if(newImageFileCount != 0){
             for(MultipartFile newImageFile : imageFileList){
@@ -176,10 +152,8 @@ public class FeedService {
                 }
             }
         }
-
         // 기존에 FeedHashtagMap 엔티티들을 전부 삭제한다.
         feedHashtagMapRepository.deleteAllByFeedId(feedId);
-
         // 그 후 입력 받은 값에 따라서 새롭게 저장한다.
         if(hashtagList != null){
             for(String hashtagInputString : hashtagList){
@@ -208,9 +182,7 @@ public class FeedService {
                 }
             }
         }
-
         feed.updateContent(content);
-
         // Feed 엔티티의 imageUrls 필드의 내용물을 수정할 때 사용할 문자열을 만들어 준다.
         StringBuilder imageUrlBuilder = new StringBuilder();
         if(resultImageUrlArr.length != 0){
@@ -219,11 +191,18 @@ public class FeedService {
                 imageUrlBuilder.append(',');
             }
         }
-
         feed.updateImageUrls(
             imageUrlBuilder.toString().equals("") ? null : imageUrlBuilder.toString()
         );
-
         return FeedUpdateResponse.from( feedRepository.save(feed), hashtagList, content );
+    }
+
+    private static void validateContentAndHashtagList(String content, List<String> hashtagList) {
+        if(content.length() > CommonConstant.CONTENT_LENGTH_LIMIT){
+            throw BaseException.CONTENT_LIMIT_EXCEED;
+        }
+        if(hashtagList != null && hashtagList.size() > CommonConstant.HASHTAG_COUNT_LIMIT){
+            throw BaseException.HASHTAG_LIMIT_EXCEED;
+        }
     }
 }

--- a/src/test/java/com/devtraces/arterest/service/feed/FeedDeleteServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/FeedDeleteServiceTest.java
@@ -1,0 +1,155 @@
+package com.devtraces.arterest.service.feed;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.devtraces.arterest.common.exception.BaseException;
+import com.devtraces.arterest.common.exception.ErrorCode;
+import com.devtraces.arterest.model.bookmark.BookmarkRepository;
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMapRepository;
+import com.devtraces.arterest.model.hashtag.HashtagRepository;
+import com.devtraces.arterest.model.like.LikeRepository;
+import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
+import com.devtraces.arterest.model.reply.Reply;
+import com.devtraces.arterest.model.reply.ReplyRepository;
+import com.devtraces.arterest.model.rereply.Rereply;
+import com.devtraces.arterest.model.rereply.RereplyRepository;
+import com.devtraces.arterest.model.user.User;
+import com.devtraces.arterest.model.user.UserRepository;
+import com.devtraces.arterest.service.s3.S3Service;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FeedDeleteServiceTest {
+
+    @Mock
+    private FeedRepository feedRepository;
+    @Mock
+    private ReplyRepository replyRepository;
+    @Mock
+    private RereplyRepository rereplyRepository;
+    @Mock
+    private LikeRepository likeRepository;
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+    @Mock
+    private LikeNumberCacheRepository likeNumberCacheRepository;
+    @Mock
+    private S3Service s3Service;
+    @Mock
+    private FeedHashtagMapRepository feedHashtagMapRepository;
+    @InjectMocks
+    private FeedDeleteService feedDeleteService;
+
+    @Test
+    @DisplayName("피드 1개 제거")
+    void successDeleteFeed(){
+        // given
+        User user = User.builder()
+            .id(1L)
+            .build();
+
+        Rereply rereply = Rereply.builder()
+            .id(1L)
+            .build();
+
+        Reply reply = Reply.builder()
+            .id(1L)
+            .rereplyList(new ArrayList<>())
+            .build();
+        reply.getRereplyList().add(rereply);
+
+        Feed feed = Feed.builder()
+            .id(1L)
+            .replyList(new ArrayList<>())
+            .user(user)
+            .imageUrls("imageUrl,")
+            .build();
+        feed.getReplyList().add(reply);
+
+        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
+
+        doNothing().when(s3Service).deleteImage(anyString());
+        doNothing().when(feedHashtagMapRepository).deleteAllByFeedId(anyLong());
+        doNothing().when(likeNumberCacheRepository).deleteLikeNumberInfo(anyLong());
+        doNothing().when(likeRepository).deleteAllByFeedId(anyLong());
+        doNothing().when(bookmarkRepository).deleteAllByFeedId(anyLong());
+        doNothing().when(rereplyRepository).deleteAllByIdIn(anyList());
+        doNothing().when(replyRepository).deleteAllByIdIn(anyList());
+        doNothing().when(feedRepository).deleteById(anyLong());
+
+        // when
+        feedDeleteService.deleteFeed(1L, 1L);
+
+        List<Long> longList = new ArrayList<>();
+        longList.add(1L);
+
+        // then
+        verify(s3Service, times(1)).deleteImage("imageUrl");
+        verify(feedHashtagMapRepository, times(1)).deleteAllByFeedId(1L);
+        verify(likeNumberCacheRepository, times(1)).deleteLikeNumberInfo(1L);
+        verify(likeRepository, times(1)).deleteAllByFeedId(1L);
+        verify(bookmarkRepository, times(1)).deleteAllByFeedId(1L);
+        verify(rereplyRepository, times(1)).deleteAllByIdIn(longList);
+        verify(replyRepository, times(1)).deleteAllByIdIn(longList);
+        verify(feedRepository).deleteById(anyLong());
+    }
+
+    @Test
+    @DisplayName("게시물 삭제 실패 - 삭제 대상 게시물을 찾을 수 없음.")
+    void failedDeleteFeedFeedNotFound(){
+        // given
+        given(feedRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when
+        BaseException exception = assertThrows(
+            BaseException.class ,
+            () -> feedDeleteService.deleteFeed(1L, 1L)
+        );
+
+        // then
+        assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("게시물 삭제 실패 - 유저 정보가 게시물 작성자 정보와 일치하지 않음.")
+    void failedDeleteFeedUserInfoNotMatch(){
+        // given
+        User user = User.builder()
+            .id(2L)
+            .build();
+
+        Feed feed = Feed.builder()
+            .id(1L)
+            .user(user)
+            .build();
+
+        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
+
+        // when
+        BaseException exception = assertThrows(
+            BaseException.class ,
+            () -> feedDeleteService.deleteFeed(1L, 1L)
+        );
+
+        // then
+        assertEquals(ErrorCode.USER_INFO_NOT_MATCH, exception.getErrorCode());
+    }
+
+}

--- a/src/test/java/com/devtraces/arterest/service/feed/FeedReadServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/FeedReadServiceTest.java
@@ -1,0 +1,241 @@
+package com.devtraces.arterest.service.feed;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.devtraces.arterest.controller.feed.dto.response.FeedResponse;
+import com.devtraces.arterest.model.bookmark.Bookmark;
+import com.devtraces.arterest.model.bookmark.BookmarkRepository;
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMapRepository;
+import com.devtraces.arterest.model.hashtag.HashtagRepository;
+import com.devtraces.arterest.model.like.LikeRepository;
+import com.devtraces.arterest.model.like.Likes;
+import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
+import com.devtraces.arterest.model.reply.Reply;
+import com.devtraces.arterest.model.reply.ReplyRepository;
+import com.devtraces.arterest.model.rereply.RereplyRepository;
+import com.devtraces.arterest.model.user.User;
+import com.devtraces.arterest.model.user.UserRepository;
+import com.devtraces.arterest.service.s3.S3Service;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+@ExtendWith(MockitoExtension.class)
+class FeedReadServiceTest {
+
+    @Mock
+    private FeedRepository feedRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private LikeRepository likeRepository;
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+    @Mock
+    private LikeNumberCacheRepository likeNumberCacheRepository;
+    @InjectMocks
+    private FeedReadService feedReadService;
+
+    @Test
+    @DisplayName("피드 리스트 읽기 성공 - 레디스에서 좋아요 개수 획득 성공한 경우.")
+    void successGetFeedListRedisServerAvailable(){
+        //given
+        Reply reply = Reply.builder()
+            .id(1L)
+            .content("this is reply")
+            .build();
+        List<Reply> replyList = new ArrayList<>();
+        replyList.add(reply);
+
+        User user = User.builder()
+            .id(1L)
+            .description("introduction")
+            .profileImageUrl("url1")
+            .nickname("dongvin99")
+            .username("박동빈")
+            .build();
+
+        Feed feed = Feed.builder()
+            .id(1L)
+            .replyList(replyList)
+            .imageUrls("url2,url3")
+            .user(user)
+            .build();
+
+        List<Feed> feedList = new ArrayList<>();
+        feedList.add(feed);
+
+        Slice<Feed> slice = new PageImpl<>(feedList);
+
+        given(feedRepository.findAllByUserId(1L, PageRequest.of(0, 10))).willReturn(slice);
+        given(userRepository.findByNickname("dongvin99")).willReturn(Optional.of(user));
+        given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(0L);
+        //given(likeRepository.countByFeedId(1L)).willReturn(0L);
+
+        //when
+        List<FeedResponse> feedResponseList = feedReadService.getFeedResponseList(1L, "dongvin99", 0, 10);
+
+        //then
+        verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
+        verify(feedRepository, times(1)).findAllByUserId(1L, PageRequest.of(0, 10));
+        assertEquals(feedResponseList.size(), 1);
+    }
+
+    @Test
+    @DisplayName("피드 리스트 읽기 성공 - 레디스에서 좋아요 개수 획득에 실패한 경우.")
+    void successGetFeedListRedisServerNotAvailable(){
+        //given
+        Reply reply = Reply.builder()
+            .id(1L)
+            .content("this is reply")
+            .build();
+        List<Reply> replyList = new ArrayList<>();
+        replyList.add(reply);
+
+        User user = User.builder()
+            .id(1L)
+            .description("introduction")
+            .profileImageUrl("url1")
+            .nickname("dongvin99")
+            .username("박동빈")
+            .build();
+
+        Feed feed = Feed.builder()
+            .id(1L)
+            .replyList(replyList)
+            .imageUrls("url2,url3")
+            .user(user)
+            .build();
+
+        List<Feed> feedList = new ArrayList<>();
+        feedList.add(feed);
+
+        Slice<Feed> slice = new PageImpl<>(feedList);
+
+        given(feedRepository.findAllByUserId(1L, PageRequest.of(0, 10))).willReturn(slice);
+        given(userRepository.findByNickname("dongvin99")).willReturn(Optional.of(user));
+        given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(null);
+        given(likeRepository.countByFeedId(1L)).willReturn(0L);
+        doNothing().when(likeNumberCacheRepository).setLikeNumber(1L, 0L);
+
+        //when
+        List<FeedResponse> feedResponseList = feedReadService.getFeedResponseList(1L, "dongvin99", 0, 10);
+
+        //then
+        verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
+        verify(likeRepository, times(1)).countByFeedId(1L);
+        verify(likeNumberCacheRepository, times(1)).setLikeNumber(1L, 0L);
+        verify(feedRepository, times(1)).findAllByUserId(1L, PageRequest.of(0, 10));
+        assertEquals(feedResponseList.size(), 1);
+    }
+
+    @Test
+    @DisplayName("피드 1개 읽기 성공 - 레디스에서 좋아요 개수 획득에 성공한 경우.")
+    void successGetOneFeedRedisServerAvailable(){
+        //given
+        Reply reply = Reply.builder()
+            .id(1L)
+            .content("this is reply")
+            .build();
+        List<Reply> replyList = new ArrayList<>();
+        replyList.add(reply);
+
+        User user = User.builder()
+            .id(1L)
+            .description("introduction")
+            .profileImageUrl("url1")
+            .nickname("dongvin99")
+            .username("박동빈")
+            .build();
+
+        Feed feed = Feed.builder()
+            .id(1L)
+            .replyList(replyList)
+            .imageUrls("url2,url3")
+            .user(user)
+            .build();
+
+        List<Likes> likesList = new ArrayList<>();
+        List<Bookmark> bookmarkList = new ArrayList<>();
+
+        given(likeRepository.findAllByUserId(1L)).willReturn(likesList);
+        given(bookmarkRepository.findAllByUserId(1L)).willReturn(bookmarkList);
+        given(feedRepository.findById(1L)).willReturn(Optional.of(feed));
+        given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(0L);
+
+        //when
+        FeedResponse feedResponse = feedReadService.getOneFeed(1L, 1L);
+
+        //then
+        verify(likeRepository, times(1)).findAllByUserId(1L);
+        verify(bookmarkRepository, times(1)).findAllByUserId(1L);
+        verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
+        verify(feedRepository, times(1)).findById(1L);
+        assertEquals(feedResponse.getFeedId(), 1L);
+    }
+
+    @Test
+    @DisplayName("피드 1개 읽기 성공 - 레디스에서 좋아요 개수 획득에 실패한 경우")
+    void successGetOneFeedRedisServerNotAvailable(){
+        //given
+        Reply reply = Reply.builder()
+            .id(1L)
+            .content("this is reply")
+            .build();
+        List<Reply> replyList = new ArrayList<>();
+        replyList.add(reply);
+
+        User user = User.builder()
+            .id(1L)
+            .description("introduction")
+            .profileImageUrl("url1")
+            .nickname("dongvin99")
+            .username("박동빈")
+            .build();
+
+        Feed feed = Feed.builder()
+            .id(1L)
+            .replyList(replyList)
+            .imageUrls("url2,url3")
+            .user(user)
+            .build();
+
+        List<Likes> likesList = new ArrayList<>();
+        List<Bookmark> bookmarkList = new ArrayList<>();
+
+        given(likeRepository.findAllByUserId(1L)).willReturn(likesList);
+        given(bookmarkRepository.findAllByUserId(1L)).willReturn(bookmarkList);
+        given(feedRepository.findById(1L)).willReturn(Optional.of(feed));
+        given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(null);
+        given(likeRepository.countByFeedId(1L)).willReturn(0L);
+        doNothing().when(likeNumberCacheRepository).setLikeNumber(1L, 0L);
+
+        //when
+        FeedResponse feedResponse = feedReadService.getOneFeed(1L, 1L);
+
+        //then
+        verify(likeRepository, times(1)).findAllByUserId(1L);
+        verify(bookmarkRepository, times(1)).findAllByUserId(1L);
+        verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
+        verify(likeRepository, times(1)).countByFeedId(1L);
+        verify(likeNumberCacheRepository, times(1)).setLikeNumber(1L, 0L);
+        verify(feedRepository, times(1)).findById(1L);
+        assertEquals(feedResponse.getFeedId(), 1L);
+    }
+
+}

--- a/src/test/java/com/devtraces/arterest/service/feed/FeedServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/FeedServiceTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.devtraces.arterest.common.constant.CommonConstant;
+import com.devtraces.arterest.model.bookmark.Bookmark;
+import com.devtraces.arterest.model.like.Likes;
 import com.devtraces.arterest.service.s3.S3Service;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.exception.ErrorCode;
@@ -307,11 +309,12 @@ class FeedServiceTest {
         Slice<Feed> slice = new PageImpl<>(feedList);
 
         given(feedRepository.findAllByUserId(1L, PageRequest.of(0, 10))).willReturn(slice);
+        given(userRepository.findByNickname("dongvin99")).willReturn(Optional.of(user));
         given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(0L);
         //given(likeRepository.countByFeedId(1L)).willReturn(0L);
 
         //when
-        List<FeedResponse> feedResponseList = feedReadService.getFeedResponseList(1L, 0, 10);
+        List<FeedResponse> feedResponseList = feedReadService.getFeedResponseList(1L, "dongvin99", 0, 10);
 
         //then
         verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
@@ -351,17 +354,18 @@ class FeedServiceTest {
         Slice<Feed> slice = new PageImpl<>(feedList);
 
         given(feedRepository.findAllByUserId(1L, PageRequest.of(0, 10))).willReturn(slice);
+        given(userRepository.findByNickname("dongvin99")).willReturn(Optional.of(user));
         given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(null);
         given(likeRepository.countByFeedId(1L)).willReturn(0L);
-        doNothing().when(likeNumberCacheRepository).setInitialLikeNumber(0L);
+        doNothing().when(likeNumberCacheRepository).setLikeNumber(1L, 0L);
 
         //when
-        List<FeedResponse> feedResponseList = feedReadService.getFeedResponseList(1L, 0, 10);
+        List<FeedResponse> feedResponseList = feedReadService.getFeedResponseList(1L, "dongvin99", 0, 10);
 
         //then
         verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
         verify(likeRepository, times(1)).countByFeedId(1L);
-        verify(likeNumberCacheRepository, times(1)).setInitialLikeNumber(0L);
+        verify(likeNumberCacheRepository, times(1)).setLikeNumber(1L, 0L);
         verify(feedRepository, times(1)).findAllByUserId(1L, PageRequest.of(0, 10));
         assertEquals(feedResponseList.size(), 1);
     }
@@ -392,16 +396,21 @@ class FeedServiceTest {
             .user(user)
             .build();
 
+        List<Likes> likesList = new ArrayList<>();
+        List<Bookmark> bookmarkList = new ArrayList<>();
+
+        given(likeRepository.findAllByUserId(1L)).willReturn(likesList);
+        given(bookmarkRepository.findAllByUserId(1L)).willReturn(bookmarkList);
         given(feedRepository.findById(1L)).willReturn(Optional.of(feed));
         given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(0L);
-        //given(likeRepository.countByFeedId(1L)).willReturn(0L);
 
         //when
-        FeedResponse feedResponse = feedReadService.getOneFeed(2L, 1L);
+        FeedResponse feedResponse = feedReadService.getOneFeed(1L, 1L);
 
         //then
+        verify(likeRepository, times(1)).findAllByUserId(1L);
+        verify(bookmarkRepository, times(1)).findAllByUserId(1L);
         verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
-        //verify(likeRepository, times(1)).countByFeedId(1L);
         verify(feedRepository, times(1)).findById(1L);
         assertEquals(feedResponse.getFeedId(), 1L);
     }
@@ -432,18 +441,25 @@ class FeedServiceTest {
             .user(user)
             .build();
 
+        List<Likes> likesList = new ArrayList<>();
+        List<Bookmark> bookmarkList = new ArrayList<>();
+
+        given(likeRepository.findAllByUserId(1L)).willReturn(likesList);
+        given(bookmarkRepository.findAllByUserId(1L)).willReturn(bookmarkList);
         given(feedRepository.findById(1L)).willReturn(Optional.of(feed));
         given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(null);
         given(likeRepository.countByFeedId(1L)).willReturn(0L);
-        doNothing().when(likeNumberCacheRepository).setInitialLikeNumber(0L);
+        doNothing().when(likeNumberCacheRepository).setLikeNumber(1L, 0L);
 
         //when
-        FeedResponse feedResponse = feedReadService.getOneFeed(2L, 1L);
+        FeedResponse feedResponse = feedReadService.getOneFeed(1L, 1L);
 
         //then
+        verify(likeRepository, times(1)).findAllByUserId(1L);
+        verify(bookmarkRepository, times(1)).findAllByUserId(1L);
         verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
         verify(likeRepository, times(1)).countByFeedId(1L);
-        verify(likeNumberCacheRepository, times(1)).setInitialLikeNumber(0L);
+        verify(likeNumberCacheRepository, times(1)).setLikeNumber(1L, 0L);
         verify(feedRepository, times(1)).findById(1L);
         assertEquals(feedResponse.getFeedId(), 1L);
     }

--- a/src/test/java/com/devtraces/arterest/service/feed/FeedServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/FeedServiceTest.java
@@ -2,7 +2,6 @@ package com.devtraces.arterest.service.feed;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -11,25 +10,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.devtraces.arterest.common.constant.CommonConstant;
-import com.devtraces.arterest.model.bookmark.Bookmark;
-import com.devtraces.arterest.model.like.Likes;
 import com.devtraces.arterest.service.s3.S3Service;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.exception.ErrorCode;
-import com.devtraces.arterest.controller.feed.dto.response.FeedResponse;
-import com.devtraces.arterest.model.bookmark.BookmarkRepository;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.feed.FeedRepository;
 import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMap;
 import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMapRepository;
 import com.devtraces.arterest.model.hashtag.Hashtag;
 import com.devtraces.arterest.model.hashtag.HashtagRepository;
-import com.devtraces.arterest.model.like.LikeRepository;
 import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
-import com.devtraces.arterest.model.reply.Reply;
-import com.devtraces.arterest.model.reply.ReplyRepository;
-import com.devtraces.arterest.model.rereply.Rereply;
-import com.devtraces.arterest.model.rereply.RereplyRepository;
 import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
 import java.util.ArrayList;
@@ -41,9 +31,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -53,15 +40,7 @@ class FeedServiceTest {
     @Mock
     private FeedRepository feedRepository;
     @Mock
-    private ReplyRepository replyRepository;
-    @Mock
-    private RereplyRepository rereplyRepository;
-    @Mock
     private UserRepository userRepository;
-    @Mock
-    private LikeRepository likeRepository;
-    @Mock
-    private BookmarkRepository bookmarkRepository;
     @Mock
     private LikeNumberCacheRepository likeNumberCacheRepository;
     @Mock
@@ -72,10 +51,6 @@ class FeedServiceTest {
     private FeedHashtagMapRepository feedHashtagMapRepository;
     @InjectMocks
     private FeedService feedService;
-    @InjectMocks
-    private FeedReadService feedReadService;
-    @InjectMocks
-    private FeedDeleteService feedDeleteService;
 
     @Test
     @DisplayName("기존 해시태그 찾아내면서 게시물 1개 생성 성공.")
@@ -275,193 +250,6 @@ class FeedServiceTest {
 
         // then
         assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
-    }
-
-    @Test
-    @DisplayName("피드 리스트 읽기 성공 - 레디스에서 좋아요 개수 획득 성공한 경우.")
-    void successGetFeedListRedisServerAvailable(){
-        //given
-        Reply reply = Reply.builder()
-            .id(1L)
-            .content("this is reply")
-            .build();
-        List<Reply> replyList = new ArrayList<>();
-        replyList.add(reply);
-
-        User user = User.builder()
-            .id(1L)
-            .description("introduction")
-            .profileImageUrl("url1")
-            .nickname("dongvin99")
-            .username("박동빈")
-            .build();
-
-        Feed feed = Feed.builder()
-            .id(1L)
-            .replyList(replyList)
-            .imageUrls("url2,url3")
-            .user(user)
-            .build();
-
-        List<Feed> feedList = new ArrayList<>();
-        feedList.add(feed);
-
-        Slice<Feed> slice = new PageImpl<>(feedList);
-
-        given(feedRepository.findAllByUserId(1L, PageRequest.of(0, 10))).willReturn(slice);
-        given(userRepository.findByNickname("dongvin99")).willReturn(Optional.of(user));
-        given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(0L);
-        //given(likeRepository.countByFeedId(1L)).willReturn(0L);
-
-        //when
-        List<FeedResponse> feedResponseList = feedReadService.getFeedResponseList(1L, "dongvin99", 0, 10);
-
-        //then
-        verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
-        verify(feedRepository, times(1)).findAllByUserId(1L, PageRequest.of(0, 10));
-        assertEquals(feedResponseList.size(), 1);
-    }
-
-    @Test
-    @DisplayName("피드 리스트 읽기 성공 - 레디스에서 좋아요 개수 획득에 실패한 경우.")
-    void successGetFeedListRedisServerNotAvailable(){
-        //given
-        Reply reply = Reply.builder()
-            .id(1L)
-            .content("this is reply")
-            .build();
-        List<Reply> replyList = new ArrayList<>();
-        replyList.add(reply);
-
-        User user = User.builder()
-            .id(1L)
-            .description("introduction")
-            .profileImageUrl("url1")
-            .nickname("dongvin99")
-            .username("박동빈")
-            .build();
-
-        Feed feed = Feed.builder()
-            .id(1L)
-            .replyList(replyList)
-            .imageUrls("url2,url3")
-            .user(user)
-            .build();
-
-        List<Feed> feedList = new ArrayList<>();
-        feedList.add(feed);
-
-        Slice<Feed> slice = new PageImpl<>(feedList);
-
-        given(feedRepository.findAllByUserId(1L, PageRequest.of(0, 10))).willReturn(slice);
-        given(userRepository.findByNickname("dongvin99")).willReturn(Optional.of(user));
-        given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(null);
-        given(likeRepository.countByFeedId(1L)).willReturn(0L);
-        doNothing().when(likeNumberCacheRepository).setLikeNumber(1L, 0L);
-
-        //when
-        List<FeedResponse> feedResponseList = feedReadService.getFeedResponseList(1L, "dongvin99", 0, 10);
-
-        //then
-        verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
-        verify(likeRepository, times(1)).countByFeedId(1L);
-        verify(likeNumberCacheRepository, times(1)).setLikeNumber(1L, 0L);
-        verify(feedRepository, times(1)).findAllByUserId(1L, PageRequest.of(0, 10));
-        assertEquals(feedResponseList.size(), 1);
-    }
-
-    @Test
-    @DisplayName("피드 1개 읽기 성공 - 레디스에서 좋아요 개수 획득에 성공한 경우.")
-    void successGetOneFeedRedisServerAvailable(){
-        //given
-        Reply reply = Reply.builder()
-            .id(1L)
-            .content("this is reply")
-            .build();
-        List<Reply> replyList = new ArrayList<>();
-        replyList.add(reply);
-
-        User user = User.builder()
-            .id(1L)
-            .description("introduction")
-            .profileImageUrl("url1")
-            .nickname("dongvin99")
-            .username("박동빈")
-            .build();
-
-        Feed feed = Feed.builder()
-            .id(1L)
-            .replyList(replyList)
-            .imageUrls("url2,url3")
-            .user(user)
-            .build();
-
-        List<Likes> likesList = new ArrayList<>();
-        List<Bookmark> bookmarkList = new ArrayList<>();
-
-        given(likeRepository.findAllByUserId(1L)).willReturn(likesList);
-        given(bookmarkRepository.findAllByUserId(1L)).willReturn(bookmarkList);
-        given(feedRepository.findById(1L)).willReturn(Optional.of(feed));
-        given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(0L);
-
-        //when
-        FeedResponse feedResponse = feedReadService.getOneFeed(1L, 1L);
-
-        //then
-        verify(likeRepository, times(1)).findAllByUserId(1L);
-        verify(bookmarkRepository, times(1)).findAllByUserId(1L);
-        verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
-        verify(feedRepository, times(1)).findById(1L);
-        assertEquals(feedResponse.getFeedId(), 1L);
-    }
-
-    @Test
-    @DisplayName("피드 1개 읽기 성공 - 레디스에서 좋아요 개수 획득에 실패한 경우")
-    void successGetOneFeedRedisServerNotAvailable(){
-        //given
-        Reply reply = Reply.builder()
-            .id(1L)
-            .content("this is reply")
-            .build();
-        List<Reply> replyList = new ArrayList<>();
-        replyList.add(reply);
-
-        User user = User.builder()
-            .id(1L)
-            .description("introduction")
-            .profileImageUrl("url1")
-            .nickname("dongvin99")
-            .username("박동빈")
-            .build();
-
-        Feed feed = Feed.builder()
-            .id(1L)
-            .replyList(replyList)
-            .imageUrls("url2,url3")
-            .user(user)
-            .build();
-
-        List<Likes> likesList = new ArrayList<>();
-        List<Bookmark> bookmarkList = new ArrayList<>();
-
-        given(likeRepository.findAllByUserId(1L)).willReturn(likesList);
-        given(bookmarkRepository.findAllByUserId(1L)).willReturn(bookmarkList);
-        given(feedRepository.findById(1L)).willReturn(Optional.of(feed));
-        given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(null);
-        given(likeRepository.countByFeedId(1L)).willReturn(0L);
-        doNothing().when(likeNumberCacheRepository).setLikeNumber(1L, 0L);
-
-        //when
-        FeedResponse feedResponse = feedReadService.getOneFeed(1L, 1L);
-
-        //then
-        verify(likeRepository, times(1)).findAllByUserId(1L);
-        verify(bookmarkRepository, times(1)).findAllByUserId(1L);
-        verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
-        verify(likeRepository, times(1)).countByFeedId(1L);
-        verify(likeNumberCacheRepository, times(1)).setLikeNumber(1L, 0L);
-        verify(feedRepository, times(1)).findById(1L);
-        assertEquals(feedResponse.getFeedId(), 1L);
     }
 
     @Test
@@ -727,101 +515,6 @@ class FeedServiceTest {
         BaseException exception = assertThrows(
             BaseException.class ,
             () -> feedService.updateFeed(1L, content, imageFileList, hashtagList, null, 1L)
-        );
-
-        // then
-        assertEquals(ErrorCode.USER_INFO_NOT_MATCH, exception.getErrorCode());
-    }
-
-    @Test
-    @DisplayName("피드 1개 제거")
-    void successDeleteFeed(){
-        // given
-        User user = User.builder()
-            .id(1L)
-            .build();
-
-        Rereply rereply = Rereply.builder()
-            .id(1L)
-            .build();
-
-        Reply reply = Reply.builder()
-            .id(1L)
-            .rereplyList(new ArrayList<>())
-            .build();
-        reply.getRereplyList().add(rereply);
-
-        Feed feed = Feed.builder()
-            .id(1L)
-            .replyList(new ArrayList<>())
-            .user(user)
-            .imageUrls("imageUrl,")
-            .build();
-        feed.getReplyList().add(reply);
-
-        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
-
-        doNothing().when(s3Service).deleteImage(anyString());
-        doNothing().when(feedHashtagMapRepository).deleteAllByFeedId(anyLong());
-        doNothing().when(likeNumberCacheRepository).deleteLikeNumberInfo(anyLong());
-        doNothing().when(likeRepository).deleteAllByFeedId(anyLong());
-        doNothing().when(bookmarkRepository).deleteAllByFeedId(anyLong());
-        doNothing().when(rereplyRepository).deleteAllByIdIn(anyList());
-        doNothing().when(replyRepository).deleteAllByIdIn(anyList());
-        doNothing().when(feedRepository).deleteById(anyLong());
-
-        // when
-        feedDeleteService.deleteFeed(1L, 1L);
-
-        List<Long> longList = new ArrayList<>();
-        longList.add(1L);
-
-        // then
-        verify(s3Service, times(1)).deleteImage("imageUrl");
-        verify(feedHashtagMapRepository, times(1)).deleteAllByFeedId(1L);
-        verify(likeNumberCacheRepository, times(1)).deleteLikeNumberInfo(1L);
-        verify(likeRepository, times(1)).deleteAllByFeedId(1L);
-        verify(bookmarkRepository, times(1)).deleteAllByFeedId(1L);
-        verify(rereplyRepository, times(1)).deleteAllByIdIn(longList);
-        verify(replyRepository, times(1)).deleteAllByIdIn(longList);
-        verify(feedRepository).deleteById(anyLong());
-    }
-
-    @Test
-    @DisplayName("게시물 삭제 실패 - 삭제 대상 게시물을 찾을 수 없음.")
-    void failedDeleteFeedFeedNotFound(){
-        // given
-        given(feedRepository.findById(anyLong())).willReturn(Optional.empty());
-
-        // when
-        BaseException exception = assertThrows(
-            BaseException.class ,
-            () -> feedDeleteService.deleteFeed(1L, 1L)
-        );
-
-        // then
-        assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
-    }
-
-    @Test
-    @DisplayName("게시물 삭제 실패 - 유저 정보가 게시물 작성자 정보와 일치하지 않음.")
-    void failedDeleteFeedUserInfoNotMatch(){
-        // given
-        User user = User.builder()
-            .id(2L)
-            .build();
-
-        Feed feed = Feed.builder()
-            .id(1L)
-            .user(user)
-            .build();
-
-        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
-
-        // when
-        BaseException exception = assertThrows(
-            BaseException.class ,
-            () -> feedDeleteService.deleteFeed(1L, 1L)
         );
 
         // then


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #69

## 📍 특이사항
- 게시물 수정의 경우에도 FE 측에서는 form-data 방식으로 요청을 보내고 싶어했고, form-data는 Post 방식으로만 보낼 수 있다고 했음. 따라서 컨트롤러 단의 게시물 수정 메서드에서 PutMapping 대신 PostMapping을 사용함.
- 게시물 리스트를 읽을 때, Token 내의 userId가 아니라, nickname PathVariable을 이용해서 결과물을 리턴하도록 변경함.
- 게시물 CRUD 테스트 코드 또한 2/22 리팩토링 결과와 같이 3 종류(FeedServiceTest, FeedReadServiceTest, FeedDeleteServiceTest)로 분할함.
- 반복사용되는 기능들은 private 메서드로 빼서 코드를 간소화 함.
- 검사로직의 경우, FE에서 구현을 완료한 것이 확인된 후에 관련 코드와 및 테스트코드들을 삭제할 예정.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
