### PR TITLE
검색 및 북마크 관련 에러 수정

### DIFF
--- a/src/main/java/com/devtraces/arterest/model/bookmark/Bookmark.java
+++ b/src/main/java/com/devtraces/arterest/model/bookmark/Bookmark.java
@@ -13,6 +13,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,7 +31,14 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @EntityListeners(value = {AuditingEntityListener.class})
-@Table(name = "bookmark")
+@Table(name = "bookmark",
+	uniqueConstraints={
+		@UniqueConstraint(
+			name="user_id_feed_id_unique",
+			columnNames={"user_id", "feed_id"}
+		)
+	}
+)
 public class Bookmark {
 
 	@Id

--- a/src/main/java/com/devtraces/arterest/model/feedhashtagmap/FeedHashtagMap.java
+++ b/src/main/java/com/devtraces/arterest/model/feedhashtagmap/FeedHashtagMap.java
@@ -13,6 +13,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,7 +28,15 @@ import org.hibernate.envers.AuditOverride;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AuditOverride(forClass = BaseEntity.class)
-@Table(name = "feed_hashtag_map")
+@Table(
+    name = "feed_hashtag_map",
+    uniqueConstraints={
+        @UniqueConstraint(
+            name="feed_id_hastag_id_unique",
+            columnNames={"feed_id", "hashtag_id"}
+        )
+    }
+)
 @Entity
 public class FeedHashtagMap extends BaseEntity {
 

--- a/src/main/java/com/devtraces/arterest/model/feedhashtagmap/FeedHashtagMapRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/feedhashtagmap/FeedHashtagMapRepository.java
@@ -1,10 +1,16 @@
 package com.devtraces.arterest.model.feedhashtagmap;
 
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.hashtag.Hashtag;
+import java.util.HashMap;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedHashtagMapRepository extends JpaRepository<FeedHashtagMap, Long> {
 	void deleteAllByFeedId(Long feed_id);
+	List<FeedHashtagMap> findByFeed(Feed feed);
+	boolean existsByHashtag(Hashtag hashtag);
 }
 

--- a/src/main/java/com/devtraces/arterest/model/hashtag/Hashtag.java
+++ b/src/main/java/com/devtraces/arterest/model/hashtag/Hashtag.java
@@ -36,8 +36,8 @@ public class Hashtag extends BaseEntity {
     private Long id;
 
 
-	  @Column(unique = true, name = "hashtag_string")
-	  private String hashtagString;
+	@Column(unique = true, name = "hashtag_string")
+	private String hashtagString;
 
     // 1:N mapping with FeedHashtagMap
     @OneToMany(mappedBy = "hashtag")

--- a/src/main/java/com/devtraces/arterest/model/like/Likes.java
+++ b/src/main/java/com/devtraces/arterest/model/like/Likes.java
@@ -8,6 +8,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +19,14 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "likes", indexes = @Index(name = "user_id_index", columnList = "user_id"))
+@Table(name = "likes", indexes = @Index(name = "user_id_index", columnList = "user_id"),
+    uniqueConstraints={
+        @UniqueConstraint(
+            name="feed_id_user_id_unique",
+            columnNames={"feed_id", "user_id"}
+        )
+    }
+)
 @Entity
 public class Likes extends BaseEntity {
 
@@ -26,6 +34,7 @@ public class Likes extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "feed_id")
     private Long feedId;
 
     @Column(name = "user_id")

--- a/src/main/java/com/devtraces/arterest/model/user/UserRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/user/UserRepository.java
@@ -16,8 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Boolean existsByNickname(String email);
 	Optional<User> findByEmail(String email);
 	Optional<User> findByNickname(String nickname);
-	Page<User> findByUsername(String username, Pageable pageable);
-	Page<User> findByNickname(String nickname, Pageable pageable);
+	Page<User> findByUsernameStartsWith(String username, Pageable pageable);
+	Page<User> findByNicknameStartsWith(String nickname, Pageable pageable);
 	Optional<User> findByKakaoUserId(long kakaoUserId);
 
 	Slice<User> findAllByIdIn(Collection<Long> idList, PageRequest pageRequest);

--- a/src/main/java/com/devtraces/arterest/service/bookmark/BookmarkService.java
+++ b/src/main/java/com/devtraces/arterest/service/bookmark/BookmarkService.java
@@ -51,8 +51,8 @@ public class BookmarkService {
 		);
 	}
 
+	@Transactional
 	public void deleteBookmark(Long userId, Long feedId) {
-
 		bookmarkRepository.deleteByUserIdAndFeedId(userId, feedId);
 	}
 }

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
@@ -4,7 +4,9 @@ import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.model.bookmark.BookmarkRepository;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMap;
 import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMapRepository;
+import com.devtraces.arterest.model.hashtag.HashtagRepository;
 import com.devtraces.arterest.model.like.LikeRepository;
 import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
 import com.devtraces.arterest.model.reply.Reply;
@@ -12,6 +14,7 @@ import com.devtraces.arterest.model.reply.ReplyRepository;
 import com.devtraces.arterest.model.rereply.Rereply;
 import com.devtraces.arterest.model.rereply.RereplyRepository;
 import com.devtraces.arterest.service.s3.S3Service;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +32,7 @@ public class FeedDeleteService {
 	private final LikeNumberCacheRepository likeNumberCacheRepository;
 	private final S3Service s3Service;
 	private final FeedHashtagMapRepository feedHashtagMapRepository;
+	private final HashtagRepository hashtagRepository;
 
 	// TODO 스프링 @Async를 사용해서 비동기 멀티 스레딩으로 처리하면 응답지연시간 최소화 가능.
 	@Transactional
@@ -46,9 +50,20 @@ public class FeedDeleteService {
 				s3Service.deleteImage(deleteTargetUrl);
 			}
 		}
-
+		
+		// 삭제될 FeedHashtagMap 데이터 목록을 가져옴.
+		List<FeedHashtagMap> feedHashtagMapList = feedHashtagMapRepository.findByFeed(feed);
+		
 		// FeedHashtagMap 테이블에서 관련 정보 모두 삭제.
 		feedHashtagMapRepository.deleteAllByFeedId(feedId);
+
+		// 삭제된 FeedHashtagMap의 feedId에 매핑된 hashtagId가 더이상 FeedHashtagMap에 존재하지 않을 경우,
+		// 해당 hastagId를 Hashtag 테이블에서 삭제함.
+		for (FeedHashtagMap feedHashtagMap : feedHashtagMapList) {
+			if(!feedHashtagMapRepository.existsByHashtag(feedHashtagMap.getHashtag())){
+				hashtagRepository.deleteById(feedHashtagMap.getHashtag().getId());
+			}
+		}
 
 		// 레디스에서 좋아요 개수 기록한 키-밸류 쌍 삭제.
 		likeNumberCacheRepository.deleteLikeNumberInfo(feedId);

--- a/src/main/java/com/devtraces/arterest/service/search/SearchService.java
+++ b/src/main/java/com/devtraces/arterest/service/search/SearchService.java
@@ -70,7 +70,7 @@ public class SearchService {
 		String keyword, Integer page, Integer pageSize) {
 		Pageable pageable = PageRequest.of(page, pageSize);
 
-		return userRepository.findByUsername(keyword, pageable)
+		return userRepository.findByUsernameStartsWith(keyword, pageable)
 			.stream().map(User -> GetUsernameSearchResponse.from(User))
 			.collect(Collectors.toList());
 	}
@@ -79,9 +79,7 @@ public class SearchService {
 		String keyword, Integer page, Integer pageSize) {
 		Pageable pageable = PageRequest.of(page, pageSize);
 
-		if(keyword.charAt(0) == '@') keyword = keyword.substring(1);
-
-		return userRepository.findByNickname(keyword, pageable)
+		return userRepository.findByNicknameStartsWith(keyword, pageable)
 			.stream().map(User -> GetNicknameSearchResponse.from(User))
 			.collect(Collectors.toList());
 	}

--- a/src/test/java/com/devtraces/arterest/service/bookmark/BookmarkServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/bookmark/BookmarkServiceTest.java
@@ -1,4 +1,4 @@
-package com.devtraces.arterest.service;
+package com.devtraces.arterest.service.bookmark;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/com/devtraces/arterest/service/feed/FeedServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/FeedServiceTest.java
@@ -31,6 +31,7 @@ import com.devtraces.arterest.model.rereply.RereplyRepository;
 import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -743,10 +744,25 @@ class FeedServiceTest {
             .build();
         feed.getReplyList().add(reply);
 
+        Hashtag hashtag = Hashtag.builder()
+            .id(1L)
+            .hashtagString("hashtag").build();
+
+        FeedHashtagMap feedHashtagMap = FeedHashtagMap.builder()
+            .feed(feed)
+            .hashtag(hashtag)
+            .build();
+
+        List<FeedHashtagMap> feedHashtagMapList = new ArrayList<>();
+        feedHashtagMapList.add(feedHashtagMap);
+
         given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
+        given(feedHashtagMapRepository.findByFeed(any())).willReturn(feedHashtagMapList);
+        given(feedHashtagMapRepository.existsByHashtag(any())).willReturn(false);
 
         doNothing().when(s3Service).deleteImage(anyString());
         doNothing().when(feedHashtagMapRepository).deleteAllByFeedId(anyLong());
+        doNothing().when(hashtagRepository).deleteById(anyLong());
         doNothing().when(likeNumberCacheRepository).deleteLikeNumberInfo(anyLong());
         doNothing().when(likeRepository).deleteAllByFeedId(anyLong());
         doNothing().when(bookmarkRepository).deleteAllByFeedId(anyLong());
@@ -763,6 +779,7 @@ class FeedServiceTest {
         // then
         verify(s3Service, times(1)).deleteImage("imageUrl");
         verify(feedHashtagMapRepository, times(1)).deleteAllByFeedId(1L);
+        verify(hashtagRepository, times(1)).deleteById(1L);
         verify(likeNumberCacheRepository, times(1)).deleteLikeNumberInfo(1L);
         verify(likeRepository, times(1)).deleteAllByFeedId(1L);
         verify(bookmarkRepository, times(1)).deleteAllByFeedId(1L);

--- a/src/test/java/com/devtraces/arterest/service/search/SearchServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/search/SearchServiceTest.java
@@ -141,7 +141,7 @@ class SearchServiceTest {
 		Page<User> userPage = new PageImpl<>(
 			responseList.subList(start, end), pageable, responseList.size());
 
-		given(userRepository.findByUsername(anyString(), any()))
+		given(userRepository.findByUsernameStartsWith(anyString(), any()))
 			.willReturn(userPage);
 
 		//when
@@ -173,7 +173,7 @@ class SearchServiceTest {
 		Page<User> userPage = new PageImpl<>(
 			responseList.subList(start, end), pageable, responseList.size());
 
-		given(userRepository.findByNickname(anyString(), any()))
+		given(userRepository.findByNicknameStartsWith(anyString(), any()))
 			.willReturn(userPage);
 
 		//when


### PR DESCRIPTION
## 📍 관련 이슈
검색 및 북마크 관련 에러가 발생하여 테이블 설정 및 로직 수정함.

## 📍 특이사항
- 검색어 앞에 특수기호 안붙이는 것으로 수정
- 이름, 닉네임 검색 일부포함 가능하게 수정
- 북마크 중복 저장 안되게 테이블 설정 변경
- 북마크 삭제 로직 수정
- 해시태그 삭제 로직 추가

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
