### PR TITLE
팔로우 관계 중복 저장 에러 수정

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
@@ -34,6 +34,7 @@ public class BaseException extends RuntimeException {
 	public static final BaseException FAILED_SEND_EMAIL = new BaseException(ErrorCode.FAILED_SEND_EMAIL);
 	public static final BaseException FOLLOW_LIMIT_EXCEED = new BaseException(ErrorCode.FOLLOW_LIMIT_EXCEED);
 	public static final BaseException FOLLOWING_SELF_NOT_ALLOWED = new BaseException(ErrorCode.FOLLOWING_SELF_NOT_ALLOWED);
+	public static final BaseException DUPLICATED_FOLLOW_OR_LIKE = new BaseException(ErrorCode.DUPLICATED_FOLLOW_OR_LIKE);
 
 
 	private final ErrorCode errorCode;

--- a/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
@@ -44,7 +44,8 @@ public enum ErrorCode {
  	FAILED_FILE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_FILE_UPLOAD", "파일 업로드에 실패했습니다."),
 	FAILED_CACHE_GET_OPERATION(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_CACHE_GET_OPERATION", "캐시서버에서 값을 가져오지 못했습니다."),
 	FAILED_CACHE_PUT_OPERATION(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_CACHE_PUT_OPERATION", "캐시서버에 값을 등록하는 것에 실패했습니다."),
-	FAILED_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_SEND_EMAIL", "메일 전송에 실패했습니다.");
+	FAILED_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_SEND_EMAIL", "메일 전송에 실패했습니다."),
+	DUPLICATED_FOLLOW_OR_LIKE(HttpStatus.INTERNAL_SERVER_ERROR, "DUPLICATED_FOLLOW_OR_LIKE", "이미 팔로우 또는 좋아요를 하였습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/devtraces/arterest/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/devtraces/arterest/configuration/SecurityConfiguration.java
@@ -56,7 +56,7 @@ public class SecurityConfiguration {
 				"/api/oauth/kakao/callback", "/api/auth/password/check",
 				"/api/auth/sign-out", "/api/auth/withdrawal",
 				"/api/users/email/**", "/api/users/nickname/**",
-				"/api/users/password", "/api/tokens/reissue", "/make-testuser", "/api/follows/**").permitAll()//.hasRole("USER")
+				"/api/users/password", "/api/tokens/reissue").permitAll()//.hasRole("USER")
 			.anyRequest().authenticated(); // permitAll() 로 하면 JwtAuthenticationEntryPoint 동작안함
 
 		return http.build();

--- a/src/main/java/com/devtraces/arterest/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/devtraces/arterest/configuration/SecurityConfiguration.java
@@ -56,7 +56,7 @@ public class SecurityConfiguration {
 				"/api/oauth/kakao/callback", "/api/auth/password/check",
 				"/api/auth/sign-out", "/api/auth/withdrawal",
 				"/api/users/email/**", "/api/users/nickname/**",
-				"/api/users/password", "/api/tokens/reissue").permitAll()//.hasRole("USER")
+				"/api/users/password", "/api/tokens/reissue", "/make-testuser", "/api/follows/**").permitAll()//.hasRole("USER")
 			.anyRequest().authenticated(); // permitAll() 로 하면 JwtAuthenticationEntryPoint 동작안함
 
 		return http.build();

--- a/src/main/java/com/devtraces/arterest/model/follow/Follow.java
+++ b/src/main/java/com/devtraces/arterest/model/follow/Follow.java
@@ -12,6 +12,7 @@ import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,7 +27,10 @@ import org.hibernate.envers.AuditOverride;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AuditOverride(forClass = BaseEntity.class)
-@Table(name = "follow", indexes = @Index(name = "following_id_index", columnList = "following_id"))
+@Table(
+    name = "follow", indexes = @Index(name = "following_id_index", columnList = "following_id"),
+    uniqueConstraints = @UniqueConstraint(columnNames = { "user_id", "following_id" })
+)
 @Entity
 public class Follow extends BaseEntity {
 

--- a/src/main/java/com/devtraces/arterest/model/follow/FollowRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/follow/FollowRepository.java
@@ -12,4 +12,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Slice<Follow> findAllByFollowingId(Long followingId, PageRequest pageRequest);
 
+    boolean existsByUserIdAndFollowingId(Long user_id, Long followingId);
+
 }

--- a/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
+++ b/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
@@ -40,6 +40,10 @@ public class FollowService {
             throw BaseException.FOLLOWING_SELF_NOT_ALLOWED;
         }
 
+        if(followRepository.existsByUserIdAndFollowingId(userId, followingUser.getId())){
+            throw BaseException.DUPLICATED_FOLLOW_OR_LIKE;
+        }
+
         // 유저 엔티티와 팔로우 엔티티는 1:N 관계이므로,
         // 유저 엔티티에는 [그 유저가 팔로우한 다른 유저의 주키 아이디 값을 저장하고 있는 팔로우 엔티티] 리스트가 저장됨.
         // 따라서 특정 유저를 찾아내면 그 유저가 팔로우 하고 있는 다른 유저들의 주키 아이디 값도 얻을 수 있음.


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #74

## 📍 특이사항
- Follow 엔티티에 user_id, following_id 이렇게 2개의 컬럼에 유니크키 제약조건을 걸고 테스트 해본 결과, ErrorController의 protected ApiErrorResponse handleRuntimeException(RuntimeException e) {...} 메서드에 걸려서 예외가 FE에 리턴이 되었지만, 그 내용이 중복 팔로우 또는 좋아요가 불가능하다는 내용이 아니었음.
- 대신 INTERTAL_SERVER_ERROR 라고만 떠서 FE에서는 구체적인 원인을 알 수 없는 상황이었음.
- 유니크키 제약조건을 어기는 요청에 대해서는 ConstraintViolationException이 발생하므로, 이것을 잡아내기 위한 ExceptionHandler 메서드를 추가해봤지만, 위에서 언급한 handleRuntimeException()에서 먼저 RuntimeException으로만 처리해서 적절한 예외를 리턴해 줄 수 없었음.
- handleRuntimeException() 메서드를 주석처리하자 ConstraintViolationException을 잡아내는 예외핸들러가 제대로 작동하면서 FE에 예외를 던져주었지만, 이 경우 handleRuntimeException() 이라는 메서드를 없애야만 작동하므로 적용하기 불가능한 해결책이었음.
- BaseException의 경우 ErrorController에서 잘 잡아냈기 때문에 일단 DB를 한 번 더 보더라도  BaseException을 던지게 만들어서 중복 팔로우 요청에 대해서 FE에 적절한 예외 메시지가 전달되게 처리되게 하였음. 그러나 여전히 유니크키 제약조건을 제대로 활용하고 있지 못하고 DB를 한번 더 보게 만드는 비효율적인 측면이 있음.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
