### PR TITLE
JWT 재발급 및 로그아웃 로직 수정

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
 	WRONG_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "WRONG_EMAIL_OR_PASSWORD", "잘못된 이메일 혹은 비밀번호입니다."),
 	WRONG_BEFORE_PASSWORD(HttpStatus.BAD_REQUEST, "WRONG_BEFORE_PASSWORD", "이전 비밀번호가 일치하지 않습니다."),
 	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
-	NOT_EXPIRED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "NOT_EXPIRED_ACCESS_TOKEN", "만료되지 않은 Access Token입니다. 비정상적인 시도이므로 로그아웃됩니다."),
+	NOT_EXPIRED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "NOT_EXPIRED_ACCESS_TOKEN", "만료되지 않은 Access Token입니다."),
 	FOLLOW_LIMIT_EXCEED(HttpStatus.BAD_REQUEST, "FOLLOW_LIMIT_EXCEED", "5000명을 초과하여 팔로우 할 수 없습니다."),
 	FOLLOWING_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOWING_SELF_NOT_ALLOWED", "자기자신을 팔로우 하는 것은 불가능합니다."),
  	INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "INVALID_IMAGE_EXTENSION", "처리할 수 없는 이미지 형식입니다."),
@@ -26,12 +26,12 @@ public enum ErrorCode {
 	NULL_AND_EMPTY_STRING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "NULL_AND_EMPTY_STRING_NOT_ALLOWED", "빈 문자열 입력은 불가능합니다."),
   
 	/* 401 */
-	ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "ACCESS_DENIED", "유효한 인증 정보가 부족합니다."),
+	ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "ACCESS_DENIED", "유효한 인증 정보가 아닙니다."),
 	EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_ACCESS_TOKEN", "Access Token이 만료되었습니다. 토큰을 재발급해주세요"),
 
 	/* 403 */
 	FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근할 수 있는 권한이 없습니다."),
-	EXPIRED_OR_PREVIOUS_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "EXPIRED_OR_PREVIOUS_REFRESH_TOKEN", "만료되었거나 이전에 발급된 Refresh Token입니다. 새로 로그인해주세요."),
+	EXPIRED_OR_PREVIOUS_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "EXPIRED_OR_PREVIOUS_REFRESH_TOKEN", "만료되었거나 이전에 발급된 Refresh Token입니다."),
 
 	/* 404 */
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "존재하지 않는 유저입니다."),

--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProperties.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProperties.java
@@ -2,7 +2,7 @@ package com.devtraces.arterest.common.jwt;
 
 public interface JwtProperties {
 
-	long ACCESS_TOKEN_EXPIRATION_TIME = 30 * 60 * 1000L; // Access Token: 30분간 토큰 유효
+	long ACCESS_TOKEN_EXPIRATION_TIME = 30 * 30 * 1000L; // Access Token: 30분간 토큰 유효
 	long REFRESH_TOKEN_EXPIRATION_TIME = 30 * 24 * 60 * 60 * 1000L;	// Refresh Token: 30일간 토큰 유효
 	String AUTHORIZATION_HEADER = "Authorization";
 	String TOKEN_PREFIX = "Bearer";

--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProperties.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProperties.java
@@ -2,7 +2,7 @@ package com.devtraces.arterest.common.jwt;
 
 public interface JwtProperties {
 
-	long ACCESS_TOKEN_EXPIRATION_TIME = 30 * 30 * 1000L; // Access Token: 30분간 토큰 유효
+	long ACCESS_TOKEN_EXPIRATION_TIME = 30 * 60 * 1000L; // Access Token: 30분간 토큰 유효
 	long REFRESH_TOKEN_EXPIRATION_TIME = 30 * 24 * 60 * 60 * 1000L;	// Refresh Token: 30일간 토큰 유효
 	String AUTHORIZATION_HEADER = "Authorization";
 	String TOKEN_PREFIX = "Bearer";

--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtProvider {
 
-	protected static final String REFRESH_TOKEN_SUBJECT_PREFIX = "refresh:";
+	public static final String REFRESH_TOKEN_SUBJECT_PREFIX = "refresh:";
 
 	private final UserDetailsService userDetailsService;
 	private final TokenRedisUtil tokenRedisUtil;
@@ -59,7 +59,7 @@ public class JwtProvider {
 
 		Date refreshTokenExpiredIn = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME);
 		String refreshToken = Jwts.builder()
-			.setSubject(REFRESH_TOKEN_SUBJECT_PREFIX + userId)	// refresh token으로 인증인가할 수 없도록 PREFIX 설정
+			.setSubject(REFRESH_TOKEN_SUBJECT_PREFIX + userId)
 			.setIssuedAt(now)
 			.setExpiration(refreshTokenExpiredIn)
 			.signWith(secretKey, SignatureAlgorithm.HS256)

--- a/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
@@ -26,9 +26,9 @@ public class JwtController {
 
 	@PostMapping("/reissue")
 	public ResponseEntity<ApiSuccessResponse<?>> reissue(
-		@RequestHeader("accessToken") String accessToken,
+		@RequestHeader("authorization") String bearerToken,
 		@CookieValue("refreshToken") String refreshToken) {
-		TokenWithNicknameDto dto = jwtService.reissue(accessToken, refreshToken);
+		TokenWithNicknameDto dto = jwtService.reissue(bearerToken, refreshToken);
 
 		HashMap hashMap = new HashMap();
 		hashMap.put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + dto.getAccessToken());

--- a/src/main/java/com/devtraces/arterest/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/devtraces/arterest/configuration/SecurityConfiguration.java
@@ -53,8 +53,7 @@ public class SecurityConfiguration {
 			.authorizeRequests()
 			.antMatchers("/api/auth/sign-up", "/api/auth/email/auth-key",
 				"/api/auth/email/auth-key/check", "/api/auth/sign-in",
-				"/api/oauth/kakao/callback", "/api/auth/password/check",
-				"/api/auth/sign-out", "/api/auth/withdrawal",
+				"/api/oauth/kakao/callback", "/api/auth/password/check", "/api/auth/withdrawal",
 				"/api/users/email/**", "/api/users/nickname/**",
 				"/api/users/password", "/api/tokens/reissue").permitAll()//.hasRole("USER")
 			.anyRequest().authenticated(); // permitAll() 로 하면 JwtAuthenticationEntryPoint 동작안함

--- a/src/main/java/com/devtraces/arterest/service/auth/util/TokenRedisUtil.java
+++ b/src/main/java/com/devtraces/arterest/service/auth/util/TokenRedisUtil.java
@@ -1,5 +1,7 @@
 package com.devtraces.arterest.service.auth.util;
 
+import static com.devtraces.arterest.common.jwt.JwtProvider.REFRESH_TOKEN_SUBJECT_PREFIX;
+
 import java.time.Duration;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +13,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class TokenRedisUtil {
-	private static final String REFRESH_TOKEN_PREFIX = "RT:";
 	private static final String ACCESS_TOKEN_BLACK_LIST_PREFIX = "AT-BL:";
 
 	private final RedisTemplate<String, String> redisTemplate;
@@ -24,7 +25,7 @@ public class TokenRedisUtil {
 		if (expirationSeconds > 0) {
 			ValueOperations<String, String> values = redisTemplate.opsForValue();
 			values.set(
-				REFRESH_TOKEN_PREFIX + userId,
+				REFRESH_TOKEN_SUBJECT_PREFIX + userId,
 				passwordEncoder.encode(refreshToken),
 				Duration.ofDays(expirationSeconds));
 		}
@@ -32,12 +33,12 @@ public class TokenRedisUtil {
 
 	public boolean hasSameRefreshToken(long userId, String refreshToken) {
 		ValueOperations<String, String> values = redisTemplate.opsForValue();
-		String encodingRefreshToken = values.get(REFRESH_TOKEN_PREFIX + userId);
+		String encodingRefreshToken = values.get(REFRESH_TOKEN_SUBJECT_PREFIX + userId);
 		return passwordEncoder.matches(refreshToken, encodingRefreshToken);
 	}
 
 	public void deleteRefreshTokenBy(long userId) {
-		redisTemplate.delete(REFRESH_TOKEN_PREFIX + userId);
+		redisTemplate.delete(REFRESH_TOKEN_SUBJECT_PREFIX + userId);
 	}
 
 	// 블랙리스트에 해당 토큰이 등록되었는지 확인하기 위해 accessToken을 key로 지정


### PR DESCRIPTION
## 📍 관련 이슈
- JWT 재발급 및 로그아웃 로직 수정함

## 📍 특이사항
- JWT 재발급시 prefix 불일치 에러 수정함
- JWT 재발급시 Authorization header 로 access token 을 받게 수정함

## 📍 테스트
- [x] API Test
