### PR TITLE
게시물 수정시 해시태그 삭제 로직 추가

### DIFF
--- a/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
@@ -57,13 +57,8 @@ public class FeedDeleteService {
 		// FeedHashtagMap 테이블에서 관련 정보 모두 삭제.
 		feedHashtagMapRepository.deleteAllByFeedId(feedId);
 
-		// 삭제된 FeedHashtagMap의 feedId에 매핑된 hashtagId가 더이상 FeedHashtagMap에 존재하지 않을 경우,
-		// 해당 hastagId를 Hashtag 테이블에서 삭제함.
-		for (FeedHashtagMap feedHashtagMap : feedHashtagMapList) {
-			if(!feedHashtagMapRepository.existsByHashtag(feedHashtagMap.getHashtag())){
-				hashtagRepository.deleteById(feedHashtagMap.getHashtag().getId());
-			}
-		}
+		// 사용되지 않는 Hashtag 삭제.
+		deleteNotUsingHashtag(feedHashtagMapList);
 
 		// 레디스에서 좋아요 개수 기록한 키-밸류 쌍 삭제.
 		likeNumberCacheRepository.deleteLikeNumberInfo(feedId);
@@ -91,5 +86,15 @@ public class FeedDeleteService {
 
 		// 피드 삭제.
 		feedRepository.deleteById(feedId);
+	}
+
+	void deleteNotUsingHashtag(List<FeedHashtagMap> feedHashtagMapList){
+		// 삭제된 FeedHashtagMap의 feedId에 매핑된 hashtagId가 더이상 FeedHashtagMap에 존재하지 않을 경우,
+		// 해당 hastagId를 Hashtag 테이블에서 삭제함.
+		for (FeedHashtagMap feedHashtagMap : feedHashtagMapList) {
+			if(!feedHashtagMapRepository.existsByHashtag(feedHashtagMap.getHashtag())){
+				hashtagRepository.deleteById(feedHashtagMap.getHashtag().getId());
+			}
+		}
 	}
 }

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
@@ -14,7 +14,6 @@ import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
 import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
 import com.devtraces.arterest.service.s3.S3Service;
-import com.google.gson.Gson;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -36,7 +35,7 @@ public class FeedService {
     private final HashtagRepository hashtagRepository;
     private final FeedHashtagMapRepository feedHashtagMapRepository;
 
-    private final Gson gson;
+    private final FeedDeleteService feedDeleteService;
 
     @Transactional
     public FeedCreateResponse createFeed(
@@ -156,8 +155,16 @@ public class FeedService {
                 }
             }
         }
+
+        // 삭제될 FeedHashtagMap 데이터 목록을 가져옴.
+        List<FeedHashtagMap> feedHashtagMapList = feedHashtagMapRepository.findByFeed(feed);
+
         // 기존에 FeedHashtagMap 엔티티들을 전부 삭제한다.
         feedHashtagMapRepository.deleteAllByFeedId(feedId);
+
+        // 사용되지 않는 Hashtag 삭제.
+        feedDeleteService.deleteNotUsingHashtag(feedHashtagMapList);
+
         // 그 후 입력 받은 값에 따라서 새롭게 저장한다.
         if(hashtagList != null){
             for(String hashtagInputString : hashtagList){


### PR DESCRIPTION
## 📍 관련 이슈
- 게시물 수정시 사용하지 않는 해시태그가 발생하는 경우 해시태그 테이블에서 삭제하는 로직 추가함.

## 📍 특이사항
- 단위 테스트의 경우 아직 에러가 발생하는 부분이 있어서, 다른 테스트코드 관련 PR 들이 머지되고 수정할 예정임.

## 📍 테스트
- [x] API Test
