### PR TITLE
프로필 조회시 팔로우 정보 추가 

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/user/UserController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
             @AuthenticationPrincipal Long userId,
             @PathVariable String nickname
     ) {
-        return ApiSuccessResponse.from(userService.getProfileByNickname(nickname));
+        return ApiSuccessResponse.from(userService.getProfileByNickname(userId, nickname));
     }
 
     @PostMapping("/profile/{nickname}")

--- a/src/main/java/com/devtraces/arterest/controller/user/dto/response/ProfileByNicknameResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/dto/response/ProfileByNicknameResponse.java
@@ -19,16 +19,20 @@ public class ProfileByNicknameResponse {
     private Boolean isFollowing;
 
 
-    public static ProfileByNicknameResponse from(User user, Integer totalFeedNumber) {
+    public static ProfileByNicknameResponse from(
+            User user, Integer totalFeedNumber,
+            Integer followerNumber, Integer followingNumber,
+            boolean isFollowing
+    ) {
         return ProfileByNicknameResponse.builder()
                 .username(user.getUsername())
                 .nickname(user.getNickname())
                 .description(user.getDescription())
                 .profileImageUrl(user.getProfileImageUrl())
                 .totalFeedNumber(totalFeedNumber)
-                .followerNumber(0) // TODO : follow 로직 완료시 추가될 예정
-                .followingNumber(0) // TODO : follow 로직 완료시 추가될 예정
-                .isFollowing(false) // TODO : follow 로직 완료시 추가될 예정
+                .followerNumber(followerNumber)
+                .followingNumber(followingNumber)
+                .isFollowing(isFollowing)
                 .build();
     }
 }

--- a/src/main/java/com/devtraces/arterest/model/follow/FollowRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/follow/FollowRepository.java
@@ -3,6 +3,7 @@ package com.devtraces.arterest.model.follow;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +13,14 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Slice<Follow> findAllByFollowingId(Long followingId, PageRequest pageRequest);
 
+    Integer countAllByFollowingId(Long followingId);
+
+
+    @Query(
+            nativeQuery = true,
+            value = "select count(*) " +
+                    "from follow f " +
+                    "where f.user_id = :userId and f.following_id = :followingId"
+    )
+    int isFollowing(Long userId, Long followingId);
 }


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #73 

## 📍 특이사항
* 팔로우 정보를 프로필 조회 로직에 추가했습니다.
* 팔로우 수, 팔로워 수, 피드 조회 사용자가 팔로우하는지 여부를 확인할 수 있습니다.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
