### PR TITLE
회원가입 시 프로필 이미지 s3에 저장 안되는 문제 해결 

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
@@ -14,17 +14,15 @@ import com.devtraces.arterest.controller.auth.dto.response.UserRegistrationRespo
 import com.devtraces.arterest.service.auth.AuthService;
 import java.util.HashMap;
 import javax.validation.Valid;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 
 import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RestController
@@ -35,8 +33,19 @@ public class AuthController {
 	public static final String ACCESS_TOKEN_PREFIX = "accessToken";
 
 	@PostMapping("sign-up")
-	public ApiSuccessResponse<UserRegistrationResponse> signUp(@ModelAttribute @Valid UserRegistrationRequest request) {
-		UserRegistrationResponse response = authService.register(request);
+	public ApiSuccessResponse<UserRegistrationResponse> signUp(
+			@RequestParam @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+			@RequestParam @NotBlank(message = "비밀번호 입력은 필수입니다.") String password,
+			@RequestParam @NotBlank(message = "username 입력은 필수입니다.") String username,
+			@RequestParam @NotBlank(message = "nickname 입력은 필수입니다.") String nickname,
+			@RequestParam MultipartFile profileImage,
+			@RequestParam String description
+			) {
+		UserRegistrationResponse response = authService.register(
+				email, password,
+				username, nickname,
+				profileImage, description
+		);
 		return ApiSuccessResponse.from(response);
 	}
 

--- a/src/main/java/com/devtraces/arterest/service/auth/AuthService.java
+++ b/src/main/java/com/devtraces/arterest/service/auth/AuthService.java
@@ -48,7 +48,7 @@ public class AuthService {
 	) {
 		validateRegistration(email, nickname);
 
-		String profileImageUrl = "";
+		String profileImageUrl = null;
 		if (profileImage != null) {
 			profileImageUrl = s3Service.uploadImage(profileImage);
 		}


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #89 

## 📍 특이사항
* MultiPartFile을 @RequestParam이 아닌 DTO로 받아 프로필 이미지가 s3에 저장되지 않는 문제가 발생했습니다. 
* 문제해결을 위해 회원가입시 필요한 정보를 모두 @RequestParam으로 받도록 했습니다. 

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
