### PR TITLE
회원가입 시 description null이어도 요청 수신 가능하게 수정 

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
@@ -23,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import reactor.util.annotation.Nullable;
 
 @RequiredArgsConstructor
 @RestController
@@ -38,8 +39,8 @@ public class AuthController {
 			@RequestParam @NotBlank(message = "비밀번호 입력은 필수입니다.") String password,
 			@RequestParam @NotBlank(message = "username 입력은 필수입니다.") String username,
 			@RequestParam @NotBlank(message = "nickname 입력은 필수입니다.") String nickname,
-			@RequestParam MultipartFile profileImage,
-			@RequestParam String description
+			@RequestParam(value = "profileImage", required = false) MultipartFile profileImage,
+			@RequestParam @Nullable String description
 			) {
 		UserRegistrationResponse response = authService.register(
 				email, password,


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #89 

## 📍 특이사항
* description이 nullable 할 수 있게 수정했습니다. 

## 📍 테스트
- [x] API Test
