### PR TITLE
좋아요 관련 API 구현

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
@@ -35,6 +35,7 @@ public class BaseException extends RuntimeException {
 	public static final BaseException FOLLOW_LIMIT_EXCEED = new BaseException(ErrorCode.FOLLOW_LIMIT_EXCEED);
 	public static final BaseException FOLLOWING_SELF_NOT_ALLOWED = new BaseException(ErrorCode.FOLLOWING_SELF_NOT_ALLOWED);
 	public static final BaseException DUPLICATED_FOLLOW_OR_LIKE = new BaseException(ErrorCode.DUPLICATED_FOLLOW_OR_LIKE);
+	public static final BaseException LIKE_NUMBER_BELLOW_ZERO = new BaseException(ErrorCode.LIKE_NUMBER_BELLOW_ZERO);
 
 
 	private final ErrorCode errorCode;

--- a/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
@@ -34,6 +34,7 @@ public class BaseException extends RuntimeException {
 	public static final BaseException FAILED_SEND_EMAIL = new BaseException(ErrorCode.FAILED_SEND_EMAIL);
 	public static final BaseException FOLLOW_LIMIT_EXCEED = new BaseException(ErrorCode.FOLLOW_LIMIT_EXCEED);
 	public static final BaseException FOLLOWING_SELF_NOT_ALLOWED = new BaseException(ErrorCode.FOLLOWING_SELF_NOT_ALLOWED);
+	public static final BaseException DUPLICATED_FOLLOW_OR_LIKE = new BaseException(ErrorCode.DUPLICATED_FOLLOW_OR_LIKE);
 
 
 	private final ErrorCode errorCode;

--- a/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 	HASHTAG_LIMIT_EXCEED(HttpStatus.BAD_REQUEST, "HASHTAG_LIMIT_EXCEED", "해시태그는 10개를 초과하여 입력할 수 없습니다."),
 	IMAGE_FILE_COUNT_LIMIT_EXCEED(HttpStatus.BAD_REQUEST, "IMAGE_FILE_COUNT_LIMIT_EXCEED", "이미지 파일의 개수는 15개를 초과할 수 없습니다."),
 	NULL_AND_EMPTY_STRING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "NULL_AND_EMPTY_STRING_NOT_ALLOWED", "빈 문자열 입력은 불가능합니다."),
+	LIKE_NUMBER_BELLOW_ZERO(HttpStatus.BAD_REQUEST, "LIKE_NUMBER_BELLOW_ZERO", "좋아요 개수가 0 입니다."),
   
 	/* 401 */
 	ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "ACCESS_DENIED", "유효한 인증 정보가 부족합니다."),

--- a/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/ErrorCode.java
@@ -44,7 +44,8 @@ public enum ErrorCode {
  	FAILED_FILE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_FILE_UPLOAD", "파일 업로드에 실패했습니다."),
 	FAILED_CACHE_GET_OPERATION(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_CACHE_GET_OPERATION", "캐시서버에서 값을 가져오지 못했습니다."),
 	FAILED_CACHE_PUT_OPERATION(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_CACHE_PUT_OPERATION", "캐시서버에 값을 등록하는 것에 실패했습니다."),
-	FAILED_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_SEND_EMAIL", "메일 전송에 실패했습니다.");
+	FAILED_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_SEND_EMAIL", "메일 전송에 실패했습니다."),
+	DUPLICATED_FOLLOW_OR_LIKE(HttpStatus.INTERNAL_SERVER_ERROR, "DUPLICATED_FOLLOW_OR_LIKE", "이미 팔로우 또는 좋아요를 하였습니다.");;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
@@ -4,6 +4,7 @@ import com.devtraces.arterest.common.response.ApiSuccessResponse;
 import com.devtraces.arterest.service.like.LikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +23,15 @@ public class LikeController {
         @PathVariable Long feedId
     ){
         likeService.pressLikeOnFeed(userId, feedId);
+        return ApiSuccessResponse.NO_DATA_RESPONSE;
+    }
+
+    @DeleteMapping("/like/{feedId}")
+    public ApiSuccessResponse<?> deleteLike(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long feedId
+    ){
+        likeService.cancelLikeOnFeed(userId, feedId);
         return ApiSuccessResponse.NO_DATA_RESPONSE;
     }
 

--- a/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
@@ -1,0 +1,12 @@
+package com.devtraces.arterest.controller.like;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LikeController {
+
+
+
+}

--- a/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
@@ -1,12 +1,28 @@
 package com.devtraces.arterest.controller.like;
 
+import com.devtraces.arterest.common.response.ApiSuccessResponse;
+import com.devtraces.arterest.service.like.LikeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class LikeController {
 
+    private final LikeService likeService;
 
+    @PostMapping("/like/{feedId}")
+    public ApiSuccessResponse<?> createLike(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long feedId
+    ){
+        likeService.pressLikeOnFeed(userId, feedId);
+        return ApiSuccessResponse.NO_DATA_RESPONSE;
+    }
 
 }

--- a/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
@@ -1,13 +1,17 @@
 package com.devtraces.arterest.controller.like;
 
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
+import com.devtraces.arterest.controller.like.dto.response.LikeResponse;
 import com.devtraces.arterest.service.like.LikeService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,6 +37,18 @@ public class LikeController {
     ){
         likeService.cancelLikeOnFeed(userId, feedId);
         return ApiSuccessResponse.NO_DATA_RESPONSE;
+    }
+
+    @GetMapping("/feeds/like/{feedId}")
+    public ApiSuccessResponse<List<LikeResponse>> getLikedUserList(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long feedId,
+        @RequestParam int page,
+        @RequestParam(required = false, defaultValue = "10") int pageSize
+    ){
+        return ApiSuccessResponse.from(
+            likeService.getLikedUserList(userId, feedId, page, pageSize)
+        );
     }
 
 }

--- a/src/main/java/com/devtraces/arterest/controller/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/dto/response/LikeResponse.java
@@ -1,6 +1,8 @@
 package com.devtraces.arterest.controller.like.dto.response;
 
 import com.devtraces.arterest.common.type.UserSignUpType;
+import com.devtraces.arterest.model.like.Likes;
+import com.devtraces.arterest.model.user.User;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -24,5 +26,18 @@ public class LikeResponse {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private UserSignUpType signupType;
+
+    public static LikeResponse from(User user){
+        return LikeResponse.builder()
+            .userId(user.getId())
+            .profileImageLink(user.getProfileImageUrl())
+            .userName(user.getUsername())
+            .nickname(user.getNickname())
+            .description(user.getDescription())
+            .createdAt(user.getCreatedAt())
+            .modifiedAt(user.getModifiedAt())
+            .signupType(user.getSignupType())
+            .build();
+    }
 
 }

--- a/src/main/java/com/devtraces/arterest/controller/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/dto/response/LikeResponse.java
@@ -1,0 +1,28 @@
+package com.devtraces.arterest.controller.like.dto.response;
+
+import com.devtraces.arterest.common.type.UserSignUpType;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LikeResponse {
+
+    private Long userId;
+    private String profileImageLink;
+    private String userName;
+    private String nickname;
+    private String description;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private UserSignUpType signupType;
+
+}

--- a/src/main/java/com/devtraces/arterest/model/like/LikeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/like/LikeRepository.java
@@ -1,6 +1,8 @@
 package com.devtraces.arterest.model.like;
 
 import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,6 +11,8 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
 
     // 특정 유저가 좋아요를 누른 피드들의 주키 번호를 찾아내기 위한 쿼리
     List<Likes> findAllByUserId(Long userId);
+
+    Slice<Likes> findAllByFeedId(Long feedId, PageRequest pageRequest);
 
     Long countByFeedId(Long feedId);
 

--- a/src/main/java/com/devtraces/arterest/model/like/LikeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/like/LikeRepository.java
@@ -12,7 +12,7 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
     // 특정 유저가 좋아요를 누른 피드들의 주키 번호를 찾아내기 위한 쿼리
     List<Likes> findAllByUserId(Long userId);
 
-    Slice<Likes> findAllByFeedId(Long feedId, PageRequest pageRequest);
+    Slice<Likes> findAllByFeedIdOrderByCreatedAtDesc(Long feedId, PageRequest pageRequest);
 
     Long countByFeedId(Long feedId);
 

--- a/src/main/java/com/devtraces/arterest/model/like/LikeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/like/LikeRepository.java
@@ -16,4 +16,6 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
 
     boolean existsByUserIdAndFeedId(Long userId, Long feedId);
 
+    void deleteByUserIdAndFeedId(Long userId, Long feedId);
+
 }

--- a/src/main/java/com/devtraces/arterest/model/like/LikeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/like/LikeRepository.java
@@ -8,13 +8,12 @@ import org.springframework.stereotype.Repository;
 public interface LikeRepository extends JpaRepository<Likes, Long> {
 
     // 특정 유저가 좋아요를 누른 피드들의 주키 번호를 찾아내기 위한 쿼리
-    // 페이징을 적용할 수 없다.
-    // 어떤 게시물을 요청할지 모르는 상황에서 페이징을 통해서 제한된 정보만을 기준으로 판단할 경우,
-    // 좋아요 누른 기록을 트루로 할지 펄스로 할지 정확하게 판단할 수 없게 되기 때문이다.
     List<Likes> findAllByUserId(Long userId);
 
     Long countByFeedId(Long feedId);
 
     void deleteAllByFeedId(Long feedId);
+
+    boolean existsByUserIdAndFeedId(Long userId, Long feedId);
 
 }

--- a/src/main/java/com/devtraces/arterest/model/likecache/LikeNumberCacheRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/likecache/LikeNumberCacheRepository.java
@@ -46,14 +46,22 @@ public class LikeNumberCacheRepository {
 
     // 좋아요 숫자를 += 1 한다.
     public void plusOneLike(Long feedId){
-        String key = getKey(feedId);
-        template.opsForValue().increment(key);
+        try {
+            String key = getKey(feedId);
+            template.opsForValue().increment(key);
+        } catch (Exception e) {
+            log.error("캐시서버에서 좋아요 개수 1 증가 기록 실패");
+        }
     }
 
     // 좋아요 숫자를 -= 1 한다.
     public void minusOneLike(Long feedId){
-        String key = getKey(feedId);
-        template.opsForValue().decrement(key);
+        try {
+            String key = getKey(feedId);
+            template.opsForValue().decrement(key);
+        } catch (Exception e) {
+            log.error("캐시서버에서 좋아요 개수 1 감소 기록 실패");
+        }
     }
 
     // 좋아요 숫자를 기록한 키-밸류 쌍을 삭제한다.

--- a/src/main/java/com/devtraces/arterest/model/user/UserRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/user/UserRepository.java
@@ -1,6 +1,7 @@
 package com.devtraces.arterest.model.user;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -21,4 +22,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByKakaoUserId(long kakaoUserId);
 
 	Slice<User> findAllByIdIn(Collection<Long> idList, PageRequest pageRequest);
+
+	List<User> findAllByIdIn(Collection<Long> id);
 }

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -1,5 +1,9 @@
 package com.devtraces.arterest.service.like;
 
+import com.devtraces.arterest.common.exception.BaseException;
+import com.devtraces.arterest.model.like.LikeRepository;
+import com.devtraces.arterest.model.like.Likes;
+import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -7,6 +11,25 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LikeService {
 
-    
+    private final LikeRepository likeRepository;
+    private final LikeNumberCacheRepository likeNumberCacheRepository;
 
+    public void pressLikeOnFeed(Long userId, Long feedId) {
+        // 유니크키 제약조건이 이미 Likes 테이블에 걸려 있지만, 이것만으로는
+        // FE에 "중복 좋아요"라는 예외 메시지를 전달하지 못하고
+        // 그저 인터널 서버 에러라고만 뜸.
+        // TODO 중복 좋아요 및 팔로우에 대한 적절한 예외처리 방법 결정후 수정 필요.
+        if(likeRepository.existsByUserIdAndFeedId(userId, feedId)){
+            throw BaseException.DUPLICATED_FOLLOW_OR_LIKE;
+        }
+
+        likeRepository.save(
+            Likes.builder()
+                .feedId(feedId)
+                .userId(userId)
+                .build()
+        );
+
+        likeNumberCacheRepository.plusOneLike(feedId);
+    }
 }

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -6,6 +6,7 @@ import com.devtraces.arterest.model.like.Likes;
 import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,10 +15,10 @@ public class LikeService {
     private final LikeRepository likeRepository;
     private final LikeNumberCacheRepository likeNumberCacheRepository;
 
+    @Transactional
     public void pressLikeOnFeed(Long userId, Long feedId) {
         // 유니크키 제약조건이 이미 Likes 테이블에 걸려 있지만, 이것만으로는
-        // FE에 "중복 좋아요"라는 예외 메시지를 전달하지 못하고
-        // 그저 인터널 서버 에러라고만 뜸.
+        // FE에 "중복 좋아요"라는 예외 메시지를 전달하지 못하고 그저 인터널 서버 에러라고만 뜸.
         // TODO 중복 좋아요 및 팔로우에 대한 적절한 예외처리 방법 결정후 수정 필요.
         if(likeRepository.existsByUserIdAndFeedId(userId, feedId)){
             throw BaseException.DUPLICATED_FOLLOW_OR_LIKE;
@@ -31,5 +32,17 @@ public class LikeService {
         );
 
         likeNumberCacheRepository.plusOneLike(feedId);
+    }
+    
+    // TODO 좋아요 취소에 대해서는 따로 알림을 보낼 필요가 없다고 생각됨.
+    @Transactional
+    public void cancelLikeOnFeed(Long userId, Long feedId) {
+        Long prevLikeNumber = likeNumberCacheRepository.getFeedLikeNumber(feedId);
+        if (prevLikeNumber == null) { prevLikeNumber = likeRepository.countByFeedId(feedId); }
+        if (prevLikeNumber.equals(0L)) { throw BaseException.LIKE_NUMBER_BELLOW_ZERO; }
+
+        likeRepository.deleteByUserIdAndFeedId(userId, feedId);
+
+        likeNumberCacheRepository.minusOneLike(feedId);
     }
 }

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -26,7 +26,7 @@ public class LikeService {
 
     @Transactional
     public void pressLikeOnFeed(Long userId, Long feedId) {
-        isFeedExists(feedId);
+        validateFeedExistence(feedId);
         // 유니크키 제약조건이 이미 Likes 테이블에 걸려 있지만, 이것만으로는
         // FE에 "중복 좋아요"라는 예외 메시지를 전달하지 못하고 그저 인터널 서버 에러라고만 뜸.
         // TODO 중복 좋아요 및 팔로우에 대한 적절한 예외처리 방법 결정후 수정 필요.
@@ -47,7 +47,7 @@ public class LikeService {
     // TODO 좋아요 취소에 대해서는 따로 알림을 보낼 필요가 없다고 생각됨.
     @Transactional
     public void cancelLikeOnFeed(Long userId, Long feedId) {
-        isFeedExists(feedId);
+        validateFeedExistence(feedId);
         Long prevLikeNumber = likeNumberCacheRepository.getFeedLikeNumber(feedId);
         if (prevLikeNumber == null) { prevLikeNumber = likeRepository.countByFeedId(feedId); }
         if (prevLikeNumber.equals(0L)) { throw BaseException.LIKE_NUMBER_BELLOW_ZERO; }
@@ -62,7 +62,7 @@ public class LikeService {
     public List<LikeResponse> getLikedUserList(
         Long userId, Long feedId, int page, int pageSize
     ) {
-        isFeedExists(feedId);
+        validateFeedExistence(feedId);
         PageRequest pageRequest = PageRequest.of(page, pageSize);
         List<Long> likedUserIdList = likeRepository
             .findAllByFeedIdOrderByCreatedAtDesc(feedId, pageRequest)
@@ -77,7 +77,7 @@ public class LikeService {
         return linkedList;
     }
 
-    private void isFeedExists(Long feedId) {
+    private void validateFeedExistence(Long feedId) {
         if(!feedRepository.existsById(feedId)){
             throw BaseException.FEED_NOT_FOUND;
         }

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -68,13 +68,8 @@ public class LikeService {
             .findAllByFeedIdOrderByCreatedAtDesc(feedId, pageRequest)
             .getContent().stream().map(Likes::getUserId).collect(Collectors.toList());
 
-        List<LikeResponse> resultList = userRepository.findAllByIdIn(likedUserIdList).stream()
+        return userRepository.findAllByIdIn(likedUserIdList).stream()
             .map(LikeResponse::from).collect(Collectors.toList());
-        LinkedList<LikeResponse> linkedList = new LinkedList<>();
-        for(LikeResponse response : resultList){
-            linkedList.addFirst(response);
-        }
-        return linkedList;
     }
 
     private void validateFeedExistence(Long feedId) {

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -1,0 +1,12 @@
+package com.devtraces.arterest.service.like;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    
+
+}

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -58,6 +58,7 @@ public class LikeService {
     }
 
     // TODO : AuthenticationPrincipal userId가 실제 좋아요 누른 유저 리스트 가져오기 API에서 사용되지 않음.
+    @Transactional(readOnly = true)
     public List<LikeResponse> getLikedUserList(
         Long userId, Long feedId, int page, int pageSize
     ) {

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -57,7 +57,8 @@ public class LikeService {
         Long userId, Long feedId, int page, int pageSize
     ) {
         PageRequest pageRequest = PageRequest.of(page, pageSize);
-        List<Long> likedUserIdList = likeRepository.findAllByFeedId(feedId, pageRequest)
+        List<Long> likedUserIdList = likeRepository
+            .findAllByFeedIdOrderByCreatedAtDesc(feedId, pageRequest)
             .getContent().stream().map(Likes::getUserId).collect(Collectors.toList());
 
         return userRepository.findAllByIdIn(likedUserIdList).stream().map(LikeResponse::from)

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -2,10 +2,12 @@ package com.devtraces.arterest.service.like;
 
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.controller.like.dto.response.LikeResponse;
+import com.devtraces.arterest.model.feed.FeedRepository;
 import com.devtraces.arterest.model.like.LikeRepository;
 import com.devtraces.arterest.model.like.Likes;
 import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
 import com.devtraces.arterest.model.user.UserRepository;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +22,11 @@ public class LikeService {
     private final UserRepository userRepository;
     private final LikeRepository likeRepository;
     private final LikeNumberCacheRepository likeNumberCacheRepository;
+    private final FeedRepository feedRepository;
 
     @Transactional
     public void pressLikeOnFeed(Long userId, Long feedId) {
+        isFeedExists(feedId);
         // 유니크키 제약조건이 이미 Likes 테이블에 걸려 있지만, 이것만으로는
         // FE에 "중복 좋아요"라는 예외 메시지를 전달하지 못하고 그저 인터널 서버 에러라고만 뜸.
         // TODO 중복 좋아요 및 팔로우에 대한 적절한 예외처리 방법 결정후 수정 필요.
@@ -43,6 +47,7 @@ public class LikeService {
     // TODO 좋아요 취소에 대해서는 따로 알림을 보낼 필요가 없다고 생각됨.
     @Transactional
     public void cancelLikeOnFeed(Long userId, Long feedId) {
+        isFeedExists(feedId);
         Long prevLikeNumber = likeNumberCacheRepository.getFeedLikeNumber(feedId);
         if (prevLikeNumber == null) { prevLikeNumber = likeRepository.countByFeedId(feedId); }
         if (prevLikeNumber.equals(0L)) { throw BaseException.LIKE_NUMBER_BELLOW_ZERO; }
@@ -56,12 +61,24 @@ public class LikeService {
     public List<LikeResponse> getLikedUserList(
         Long userId, Long feedId, int page, int pageSize
     ) {
+        isFeedExists(feedId);
         PageRequest pageRequest = PageRequest.of(page, pageSize);
         List<Long> likedUserIdList = likeRepository
             .findAllByFeedIdOrderByCreatedAtDesc(feedId, pageRequest)
             .getContent().stream().map(Likes::getUserId).collect(Collectors.toList());
 
-        return userRepository.findAllByIdIn(likedUserIdList).stream().map(LikeResponse::from)
-            .collect(Collectors.toList());
+        List<LikeResponse> resultList = userRepository.findAllByIdIn(likedUserIdList).stream()
+            .map(LikeResponse::from).collect(Collectors.toList());
+        LinkedList<LikeResponse> linkedList = new LinkedList<>();
+        for(LikeResponse response : resultList){
+            linkedList.addFirst(response);
+        }
+        return linkedList;
+    }
+
+    private void isFeedExists(Long feedId) {
+        if(!feedRepository.existsById(feedId)){
+            throw BaseException.FEED_NOT_FOUND;
+        }
     }
 }

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -1,10 +1,15 @@
 package com.devtraces.arterest.service.like;
 
 import com.devtraces.arterest.common.exception.BaseException;
+import com.devtraces.arterest.controller.like.dto.response.LikeResponse;
 import com.devtraces.arterest.model.like.LikeRepository;
 import com.devtraces.arterest.model.like.Likes;
 import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
+import com.devtraces.arterest.model.user.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LikeService {
 
+    private final UserRepository userRepository;
     private final LikeRepository likeRepository;
     private final LikeNumberCacheRepository likeNumberCacheRepository;
 
@@ -33,7 +39,7 @@ public class LikeService {
 
         likeNumberCacheRepository.plusOneLike(feedId);
     }
-    
+
     // TODO 좋아요 취소에 대해서는 따로 알림을 보낼 필요가 없다고 생각됨.
     @Transactional
     public void cancelLikeOnFeed(Long userId, Long feedId) {
@@ -44,5 +50,17 @@ public class LikeService {
         likeRepository.deleteByUserIdAndFeedId(userId, feedId);
 
         likeNumberCacheRepository.minusOneLike(feedId);
+    }
+
+    // TODO : AuthenticationPrincipal userId가 실제 좋아요 누른 유저 리스트 가져오기 API에서 사용되지 않음.
+    public List<LikeResponse> getLikedUserList(
+        Long userId, Long feedId, int page, int pageSize
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, pageSize);
+        List<Long> likedUserIdList = likeRepository.findAllByFeedId(feedId, pageRequest)
+            .getContent().stream().map(Likes::getUserId).collect(Collectors.toList());
+
+        return userRepository.findAllByIdIn(likedUserIdList).stream().map(LikeResponse::from)
+            .collect(Collectors.toList());
     }
 }

--- a/src/test/http/test.http
+++ b/src/test/http/test.http
@@ -78,10 +78,7 @@ Content-Type: application/json
 DELETE http://localhost:8080/api/feeds/1/replies/1/rereplies/1/1
 
 
-### 테스트 유저 생성
-POST http://localhost:8080/make-testuser
-
-### make test user - 테스트 유저 1~4번 생성.
+### 테스트 유저 생성 & 초기 작업 진행.
 POST http://localhost:8080/make-testuser
 
 ### 팔로우 관계 설정 / 1>2 - OK
@@ -107,3 +104,44 @@ GET http://localhost:8080/api/follows/follower/two?userId=1&page=0
 
 ### 팔로우 관계 제거 : 1번이 3번을 언팔로우 했다. - OK
 DELETE http://localhost:8080/api/follows/three?userId=1
+
+
+
+
+
+
+### 테스트 유저 생성 & 초기 작업 진행.
+POST http://localhost:8080/make-testuser
+
+### 1번 유저가 피드에 좋아요 누름 - OK
+POST http://localhost:8080/api/like/1?userId=1
+
+### 2번 유저가 피드에 좋아요 누름 - OK
+POST http://localhost:8080/api/like/1?userId=2
+
+### 3번 유저가 피드에 좋아요 누름 - OK
+POST http://localhost:8080/api/like/1?userId=3
+
+### 4번 유저가 피드에 좋아요 누름 - OK
+POST http://localhost:8080/api/like/1?userId=4
+
+### 5번 유저가 피드에 좋아요 누름 - OK
+POST http://localhost:8080/api/like/1?userId=5
+
+### 페이지 사이즈 3으로 놓고 좋아요 누른 유저들 조회 0 페이지 조회. - OK
+GET http://localhost:8080/api/feeds/like/1?userId=1&page=0&pageSize=3
+
+### 페이지 사이즈 3으로 놓고 좋아요 누른 유저들 조회 1 페이지 조회. - OK
+GET http://localhost:8080/api/feeds/like/1?userId=1&page=1&pageSize=3
+
+### 1번이 좋아요 취소. - OK
+DELETE http://localhost:8080/api/like/1?userId=1
+
+### 2번이 좋아요 취소. - OK
+DELETE http://localhost:8080/api/like/1?userId=2
+
+### 피드 1개 읽기 - 좋아요 개수 잘 들어오나? - OK
+GET http://localhost:8080/api/feeds/1?userId=6
+
+### 피드 리스트로 읽기 - 좋아요 개수 잘 들어오나? - OK
+GET http://localhost:8080/api/feeds/list/six?userId=6&page=0

--- a/src/test/java/com/devtraces/arterest/service/like/LikeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/like/LikeServiceTest.java
@@ -1,17 +1,33 @@
 package com.devtraces.arterest.service.like;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import com.devtraces.arterest.common.exception.BaseException;
+import com.devtraces.arterest.common.exception.ErrorCode;
+import com.devtraces.arterest.controller.like.dto.response.LikeResponse;
 import com.devtraces.arterest.model.feed.FeedRepository;
 import com.devtraces.arterest.model.like.LikeRepository;
+import com.devtraces.arterest.model.like.Likes;
 import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
+import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 
 @ExtendWith(MockitoExtension.class)
 class LikeServiceTest {
@@ -32,66 +48,173 @@ class LikeServiceTest {
     @DisplayName("좋아요 누르기 성공.")
     void successPressLike(){
         // given
+        given(feedRepository.existsById(anyLong())).willReturn(true);
+
+        Likes likeEntity = Likes.builder()
+            .id(1L)
+            .userId(1L)
+            .feedId(1L)
+            .build();
+
+        given(likeRepository.save(any())).willReturn(likeEntity);
+        doNothing().when(likeNumberCacheRepository).plusOneLike(1L);
 
         // when
+        likeService.pressLikeOnFeed(1L ,1L);
 
         // then
-
+        verify(feedRepository, times(1)).existsById(1L);
+        verify(likeRepository, times(1)).save(any());
+        verify(likeNumberCacheRepository, times(1)).plusOneLike(1L);
     }
 
     @Test
     @DisplayName("좋아요 누르기 실패 - 게시물 못 찾음.")
     void failedPressLikeFeedNotFound(){
         // given
+        given(feedRepository.existsById(anyLong())).willReturn(false);
 
         // when
+        BaseException exception = assertThrows(
+            BaseException.class ,
+            () -> likeService.pressLikeOnFeed(1L, 1L)
+        );
 
         // then
-
+        assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
     }
 
     @Test
-    @DisplayName("좋아요 취소 성공.")
-    void successCancelLike(){
+    @DisplayName("좋아요 취소 성공. - 레디스 정상 작동")
+    void successCancelLikeRedisAvailable(){
         // given
+        given(feedRepository.existsById(anyLong())).willReturn(true);
+        given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(1L);
+        doNothing().when(likeRepository).deleteByUserIdAndFeedId(anyLong(), anyLong());
+        doNothing().when(likeNumberCacheRepository).minusOneLike(anyLong());
 
         // when
+        likeService.cancelLikeOnFeed(1L ,1L);
 
         // then
+        verify(feedRepository, times(1)).existsById(1L);
+        verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
+        verify(likeRepository, times(1)).deleteByUserIdAndFeedId(1L, 1L);
+        verify(likeNumberCacheRepository, times(1)).minusOneLike(1L);
+    }
 
+    @Test
+    @DisplayName("좋아요 취소 성공. - 레디스 작동 불가")
+    void successCancelLikeRedisNotAvailable(){
+        // given
+        given(feedRepository.existsById(anyLong())).willReturn(true);
+        given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(null);
+        given(likeRepository.countByFeedId(1L)).willReturn(1L);
+        doNothing().when(likeRepository).deleteByUserIdAndFeedId(anyLong(), anyLong());
+        doNothing().when(likeNumberCacheRepository).minusOneLike(anyLong());
+
+        // when
+        likeService.cancelLikeOnFeed(1L ,1L);
+
+        // then
+        verify(feedRepository, times(1)).existsById(1L);
+        verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
+        verify(likeRepository, times(1)).countByFeedId(1L);
+        verify(likeRepository, times(1)).deleteByUserIdAndFeedId(1L, 1L);
+        verify(likeNumberCacheRepository, times(1)).minusOneLike(1L);
     }
 
     @Test
     @DisplayName("좋아요 취소 실패 - 게시물 못 찾음.")
     void failedCancelLikeFeedNotFound(){
         // given
+        given(feedRepository.existsById(anyLong())).willReturn(false);
 
         // when
+        BaseException exception = assertThrows(
+            BaseException.class ,
+            () -> likeService.cancelLikeOnFeed(1L, 1L)
+        );
 
         // then
+        assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
+    }
 
+    @Test
+    @DisplayName("좋아요 취소 실패 - 좋아요 개수가 0 개임.")
+    void failedCancelLikeZeroLikeNumber(){
+        // given
+        given(feedRepository.existsById(anyLong())).willReturn(true);
+        given(likeNumberCacheRepository.getFeedLikeNumber(anyLong())).willReturn(0L);
+
+        // when
+        BaseException exception = assertThrows(
+            BaseException.class ,
+            () -> likeService.cancelLikeOnFeed(1L, 1L)
+        );
+
+        // then
+        assertEquals(ErrorCode.LIKE_NUMBER_BELLOW_ZERO, exception.getErrorCode());
     }
 
     @Test
     @DisplayName("좋아요 누른 사람 리스트 확인 성공")
     void successGetLikedUserList(){
-        // given
+        //given
+        given(feedRepository.existsById(1L)).willReturn(true);
 
-        // when
+        User user = User.builder()
+            .id(1L)
+            .description("introduction")
+            .profileImageUrl("url1")
+            .nickname("dongvin99")
+            .username("박동빈")
+            .build();
 
-        // then
+        Likes likeEntity = Likes.builder()
+            .id(1L)
+            .userId(1L)
+            .feedId(1L)
+            .build();
 
+        List<Likes> likesList = new ArrayList<>();
+        likesList.add(likeEntity);
+
+        Slice<Likes> likeSlice = new PageImpl<>(likesList);
+
+        List<Long> userIdList = new ArrayList<>();
+        userIdList.add(1L);
+
+        List<User> userEntityList = new ArrayList<>();
+        userEntityList.add(user);
+
+        given(likeRepository.findAllByFeedIdOrderByCreatedAtDesc(1L, PageRequest.of(0,10))).willReturn(likeSlice);
+        given(userRepository.findAllByIdIn(userIdList)).willReturn(userEntityList);
+
+        //when
+        List<LikeResponse> responseList = likeService.getLikedUserList(1L, 1L, 0, 10);
+
+        //then
+        verify(feedRepository, times(1)).existsById(1L);
+        verify(likeRepository, times(1)).findAllByFeedIdOrderByCreatedAtDesc(1L, PageRequest.of(0, 10));
+        verify(userRepository, times(1)).findAllByIdIn(userIdList);
+        assertEquals(responseList.size(), 1);
     }
 
     @Test
     @DisplayName("좋아요 누른 사람 리스트 확인 실패 - 게시물 못 찾음.")
     void failedGetLikedUserListFeedNotFound(){
         // given
+        given(feedRepository.existsById(anyLong())).willReturn(false);
 
         // when
+        BaseException exception = assertThrows(
+            BaseException.class ,
+            () -> likeService.getLikedUserList(1L, 1L, 0, 10)
+        );
 
         // then
-
+        assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
     }
 
 }

--- a/src/test/java/com/devtraces/arterest/service/like/LikeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/like/LikeServiceTest.java
@@ -1,0 +1,97 @@
+package com.devtraces.arterest.service.like;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.model.like.LikeRepository;
+import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
+import com.devtraces.arterest.model.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private LikeRepository likeRepository;
+    @Mock
+    private LikeNumberCacheRepository likeNumberCacheRepository;
+    @Mock
+    private FeedRepository feedRepository;
+
+    @InjectMocks
+    private LikeService likeService;
+
+    @Test
+    @DisplayName("좋아요 누르기 성공.")
+    void successPressLike(){
+        // given
+
+        // when
+
+        // then
+
+    }
+
+    @Test
+    @DisplayName("좋아요 누르기 실패 - 게시물 못 찾음.")
+    void failedPressLikeFeedNotFound(){
+        // given
+
+        // when
+
+        // then
+
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 성공.")
+    void successCancelLike(){
+        // given
+
+        // when
+
+        // then
+
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 실패 - 게시물 못 찾음.")
+    void failedCancelLikeFeedNotFound(){
+        // given
+
+        // when
+
+        // then
+
+    }
+
+    @Test
+    @DisplayName("좋아요 누른 사람 리스트 확인 성공")
+    void successGetLikedUserList(){
+        // given
+
+        // when
+
+        // then
+
+    }
+
+    @Test
+    @DisplayName("좋아요 누른 사람 리스트 확인 실패 - 게시물 못 찾음.")
+    void failedGetLikedUserListFeedNotFound(){
+        // given
+
+        // when
+
+        // then
+
+    }
+
+}


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #46

## 📍 특이사항
- 중복 좋아요에 대한 금지 로직이 적용돼 있음.
- 좋아요 누른 사람 리스트 요청 시, 최근에 좋아요 누른 사람이 먼저 뜨게 하였음.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
