### PR TITLE
로그인 및 토큰 재발급 시 refresh token 전송방식 변경

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
@@ -13,6 +13,7 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 import java.util.Date;
+import javax.servlet.http.Cookie;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
@@ -69,17 +70,17 @@ public class JwtProvider {
 
 		return TokenDto.builder()
 			.accessToken(accessToken)
-			.responseCookie(generateCookie(refreshToken))
+			.cookie(generateCookie(refreshToken))
 			.build();
 	}
 
-	private ResponseCookie generateCookie(String refreshToken) {
-		return ResponseCookie.from("refreshToken", refreshToken)
-			.httpOnly(true)
-			.secure(true)
-			.sameSite("None")
-			.path("/refresh-token")
-			.build();
+	private Cookie generateCookie(String refreshToken) {
+		Cookie cookie = new Cookie("refreshToken", refreshToken);
+
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+
+		return cookie;
 	}
 
 	// JWT 토큰에서 인증 정보 조회

--- a/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 
 import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -30,18 +31,18 @@ public class JwtController {
 	@PostMapping("/reissue")
 	public ResponseEntity<ApiSuccessResponse<?>> reissue(
 		@RequestHeader("authorization") String bearerToken,
-		@RequestHeader("cookie") String cookie
+		@CookieValue("refreshToken") String refreshToken,
+		HttpServletResponse response
 	) {
-		log.info("cookie: " + cookie);
-		String refreshToken = cookie.split("; ")[0].replace("refreshToken=","");
 		TokenWithNicknameDto dto = jwtService.reissue(bearerToken, refreshToken);
 
 		HashMap hashMap = new HashMap();
 		hashMap.put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + dto.getAccessToken());
 		hashMap.put("nickname", dto.getNickname());
 
+		response.addCookie(dto.getCookie());
+
 		return ResponseEntity.ok()
-			.header(SET_COOKIE, dto.getResponseCookie().toString())
 			.body(ApiSuccessResponse.from(hashMap));
 	}
 }

--- a/src/main/java/com/devtraces/arterest/common/jwt/dto/TokenDto.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/dto/TokenDto.java
@@ -1,9 +1,9 @@
 package com.devtraces.arterest.common.jwt.dto;
 
+import javax.servlet.http.Cookie;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.http.ResponseCookie;
 
 @Getter
 @Builder
@@ -11,6 +11,6 @@ import org.springframework.http.ResponseCookie;
 public class TokenDto {
 
 	private String accessToken;
-	private ResponseCookie responseCookie;
+	private Cookie cookie;
 
 }

--- a/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
@@ -13,6 +13,7 @@ import com.devtraces.arterest.controller.auth.dto.request.UserRegistrationReques
 import com.devtraces.arterest.controller.auth.dto.response.UserRegistrationResponse;
 import com.devtraces.arterest.service.auth.AuthService;
 import java.util.HashMap;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -63,7 +64,10 @@ public class AuthController {
 	}
 
 	@PostMapping("/sign-in")
-	public ResponseEntity<ApiSuccessResponse<?>> signIn(@RequestBody @Valid SignInRequest request) {
+	public ResponseEntity<ApiSuccessResponse<?>> signIn(
+		@RequestBody @Valid SignInRequest request,
+		HttpServletResponse response
+	) {
 		TokenWithNicknameDto dto = authService.signInAndGenerateJwtToken(
 				request.getEmail(),
 				request.getPassword()
@@ -73,8 +77,9 @@ public class AuthController {
 		hashMap.put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + dto.getAccessToken());
 		hashMap.put("nickname", dto.getNickname());
 
+		response.addCookie(dto.getCookie());
+
 		return ResponseEntity.ok()
-				.header(SET_COOKIE, dto.getResponseCookie().toString())
 				.body(ApiSuccessResponse.from(hashMap));
 	}
 

--- a/src/main/java/com/devtraces/arterest/controller/auth/OauthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/OauthController.java
@@ -6,6 +6,7 @@ import com.devtraces.arterest.service.auth.OauthService;
 import java.util.HashMap;
 
 import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,7 +26,10 @@ public class OauthController {
     private final OauthService oauthService;
 
     @PostMapping("/kakao/callback")
-    public ResponseEntity<ApiSuccessResponse<?>> oauthKakaoSignIn(@RequestBody OauthKakaoSignInRequest request) {
+    public ResponseEntity<ApiSuccessResponse<?>> oauthKakaoSignIn(
+        @RequestBody OauthKakaoSignInRequest request,
+        HttpServletResponse response
+    ) {
         TokenWithNicknameDto dto =
                 oauthService.oauthKakaoSignIn(request.getAccessTokenFromKakao());
 
@@ -33,8 +37,9 @@ public class OauthController {
         hashMap.put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + dto.getAccessToken());
         hashMap.put("nickname", dto.getNickname());
 
+        response.addCookie(dto.getCookie());
+
         return ResponseEntity.ok()
-            .header(SET_COOKIE, dto.getResponseCookie().toString())
             .body(ApiSuccessResponse.from(hashMap));
     }
 }

--- a/src/main/java/com/devtraces/arterest/controller/auth/dto/TokenWithNicknameDto.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/dto/TokenWithNicknameDto.java
@@ -1,8 +1,12 @@
 package com.devtraces.arterest.controller.auth.dto;
 
 import com.devtraces.arterest.common.jwt.dto.TokenDto;
-import lombok.*;
-import org.springframework.http.ResponseCookie;
+import javax.servlet.http.Cookie;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
@@ -12,13 +16,13 @@ public class TokenWithNicknameDto {
 
     private String nickname;
     private String accessToken;
-    private ResponseCookie responseCookie;
+    private Cookie cookie;
 
     public static TokenWithNicknameDto from(String nickname, TokenDto tokenDto) {
         return TokenWithNicknameDto.builder()
                 .nickname(nickname)
                 .accessToken(tokenDto.getAccessToken())
-                .responseCookie(tokenDto.getResponseCookie())
+                .cookie(tokenDto.getCookie())
                 .build();
     }
 }


### PR DESCRIPTION
## 📍 관련 이슈
- 기존에 refresh token 을 쿠키에 담아, 쿠키를 문자열로 전환한 후 헤더에 담아 전송하였는데, 이 경우 쿠키가 아니기 때문에 FE 측에서 쿠키를 전송받지 못함. 따라서 쿠키 객체를 그대로 전송하는 것으로 변경함.

## 📍 특이사항
- HttpServletResponse 를 활용하여 쿠키 객체를 전송함.

## 📍 테스트
- [x] API Test
