### PR TITLE
중복 팔로우 및 좋아요에 예외 던지지 않음 & 중복 검사로직 간소화

### DIFF
--- a/src/main/java/com/devtraces/arterest/model/follow/Follow.java
+++ b/src/main/java/com/devtraces/arterest/model/follow/Follow.java
@@ -28,8 +28,7 @@ import org.hibernate.envers.AuditOverride;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AuditOverride(forClass = BaseEntity.class)
 @Table(
-    name = "follow", indexes = @Index(name = "following_id_index", columnList = "following_id"),
-    uniqueConstraints = @UniqueConstraint(columnNames = { "user_id", "following_id" })
+    name = "follow", indexes = @Index(name = "following_id_index", columnList = "following_id")
 )
 @Entity
 public class Follow extends BaseEntity {

--- a/src/main/java/com/devtraces/arterest/model/like/Likes.java
+++ b/src/main/java/com/devtraces/arterest/model/like/Likes.java
@@ -19,14 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "likes", indexes = @Index(name = "user_id_index", columnList = "user_id"),
-    uniqueConstraints={
-        @UniqueConstraint(
-            name="feed_id_user_id_unique",
-            columnNames={"feed_id", "user_id"}
-        )
-    }
-)
+@Table(name = "likes", indexes = @Index(name = "user_id_index", columnList = "user_id"))
 @Entity
 public class Likes extends BaseEntity {
 

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
@@ -208,7 +208,7 @@ public class FeedService {
         return FeedUpdateResponse.from( feedRepository.save(feed), hashtagList, content );
     }
 
-    private static void validateContentAndHashtagList(String content, List<String> hashtagList) {
+    private void validateContentAndHashtagList(String content, List<String> hashtagList) {
         if(content.length() > CommonConstant.CONTENT_LENGTH_LIMIT){
             throw BaseException.CONTENT_LIMIT_EXCEED;
         }

--- a/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
+++ b/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
@@ -40,19 +40,19 @@ public class FollowService {
             throw BaseException.FOLLOWING_SELF_NOT_ALLOWED;
         }
 
-        if(followRepository.existsByUserIdAndFollowingId(userId, followingUser.getId())){
-            throw BaseException.DUPLICATED_FOLLOW_OR_LIKE;
+        if(!followRepository.existsByUserIdAndFollowingId(userId, followingUser.getId())){
+            // 중복 팔로우가 아닌 경우에만 저장이 진행됨.
+            // 예외를 던지지 않게 함.
+            // 유저 엔티티와 팔로우 엔티티는 1:N 관계이므로,
+            // 유저 엔티티에는 [그 유저가 팔로우한 다른 유저의 주키 아이디 값을 저장하고 있는 팔로우 엔티티] 리스트가 저장됨.
+            // 따라서 특정 유저를 찾아내면 그 유저가 팔로우 하고 있는 다른 유저들의 주키 아이디 값도 얻을 수 있음.
+            followRepository.save(
+                Follow.builder()
+                    .user(followerUser)
+                    .followingId(followingUser.getId())
+                    .build()
+            );
         }
-
-        // 유저 엔티티와 팔로우 엔티티는 1:N 관계이므로,
-        // 유저 엔티티에는 [그 유저가 팔로우한 다른 유저의 주키 아이디 값을 저장하고 있는 팔로우 엔티티] 리스트가 저장됨.
-        // 따라서 특정 유저를 찾아내면 그 유저가 팔로우 하고 있는 다른 유저들의 주키 아이디 값도 얻을 수 있음.
-        followRepository.save(
-            Follow.builder()
-                .user(followerUser)
-                .followingId(followingUser.getId())
-                .build()
-        );
     }
 
     /*

--- a/src/main/java/com/devtraces/arterest/service/reply/ReplyService.java
+++ b/src/main/java/com/devtraces/arterest/service/reply/ReplyService.java
@@ -31,9 +31,7 @@ public class ReplyService {
 
     @Transactional
     public ReplyResponse createReply(Long userId, Long feedId, ReplyRequest replyRequest) {
-        if(replyRequest.getContent() == null || replyRequest.getContent().equals("")){
-            throw BaseException.NULL_AND_EMPTY_STRING_NOT_ALLOWED;
-        }
+        validateReplyRequest(replyRequest);
         if(replyRequest.getContent().length() > CommonConstant.CONTENT_LENGTH_LIMIT){
             throw BaseException.CONTENT_LIMIT_EXCEED;
         }
@@ -61,9 +59,7 @@ public class ReplyService {
 
     @Transactional
     public ReplyResponse updateReply(Long userId, Long replyId, ReplyRequest replyRequest) {
-        if(replyRequest.getContent() == null || replyRequest.getContent().equals("")){
-            throw BaseException.NULL_AND_EMPTY_STRING_NOT_ALLOWED;
-        }
+        validateReplyRequest(replyRequest);
         if(replyRequest.getContent().length() > CommonConstant.CONTENT_LENGTH_LIMIT){
             throw BaseException.CONTENT_LIMIT_EXCEED;
         }
@@ -96,5 +92,11 @@ public class ReplyService {
 
         // 댓글을 삭제한다.
         replyRepository.deleteById(replyId);
+    }
+
+    private static void validateReplyRequest(ReplyRequest replyRequest) {
+        if(replyRequest.getContent() == null || replyRequest.getContent().equals("")){
+            throw BaseException.NULL_AND_EMPTY_STRING_NOT_ALLOWED;
+        }
     }
 }

--- a/src/main/java/com/devtraces/arterest/service/rereply/RereplyService.java
+++ b/src/main/java/com/devtraces/arterest/service/rereply/RereplyService.java
@@ -29,12 +29,7 @@ public class RereplyService {
     @Transactional
     public RereplyResponse createRereply(
         Long userId, Long feedId, Long replyId, RereplyRequest rereplyRequest) {
-        if(rereplyRequest.getContent() == null || rereplyRequest.getContent().equals("")){
-            throw BaseException.NULL_AND_EMPTY_STRING_NOT_ALLOWED;
-        }
-        if(rereplyRequest.getContent().length() > CommonConstant.CONTENT_LENGTH_LIMIT){
-            throw BaseException.CONTENT_LIMIT_EXCEED;
-        }
+        validateRereplyRequest(rereplyRequest);
         User authorUser = userRepository.findById(userId).orElseThrow(
             () -> BaseException.USER_NOT_FOUND
         );
@@ -65,12 +60,7 @@ public class RereplyService {
     public RereplyResponse updateRereply(
         Long userId, Long feedId, Long rereplyId, RereplyRequest rereplyRequest
     ) {
-        if(rereplyRequest.getContent() == null || rereplyRequest.getContent().equals("")){
-            throw BaseException.NULL_AND_EMPTY_STRING_NOT_ALLOWED;
-        }
-        if(rereplyRequest.getContent().length() > CommonConstant.CONTENT_LENGTH_LIMIT){
-            throw BaseException.CONTENT_LIMIT_EXCEED;
-        }
+        validateRereplyRequest(rereplyRequest);
         Rereply rereply = rereplyRepository.findById(rereplyId).orElseThrow(
             () -> BaseException.REREPLY_NOT_FOUND
         );
@@ -90,5 +80,14 @@ public class RereplyService {
             throw BaseException.USER_INFO_NOT_MATCH;
         }
         rereplyRepository.deleteById(rereplyId);
+    }
+
+    private void validateRereplyRequest(RereplyRequest rereplyRequest) {
+        if(rereplyRequest.getContent() == null || rereplyRequest.getContent().equals("")){
+            throw BaseException.NULL_AND_EMPTY_STRING_NOT_ALLOWED;
+        }
+        if(rereplyRequest.getContent().length() > CommonConstant.CONTENT_LENGTH_LIMIT){
+            throw BaseException.CONTENT_LIMIT_EXCEED;
+        }
     }
 }

--- a/src/test/java/com/devtraces/arterest/service/follow/FollowServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/follow/FollowServiceTest.java
@@ -20,6 +20,7 @@ import com.devtraces.arterest.model.user.UserRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -141,6 +142,7 @@ class FollowServiceTest {
     }
 
     @Test
+    @Disabled
     @DisplayName("팔로우 관계 추가 실패 - 이미 팔로우한 사람 또 팔로우하려 함")
     void failedCreateFollowRelationDuplicatedFollowRequest(){
         // given


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #101 

## 📍 특이사항
- 2/24/금 멘토링 내용에 따라서 중복 팔로우 및 좋아요에 예외 던지지 않고 대신 검사 후 통과한 부분만 저장하게 함.
- 팔로우 및 좋아요 테이블에 유니크키 제약조건 삭제함.
- 댓글 및 대댓글 서비스에서 반복되는 검사코드를 private 메서드로 빼내서 간소화 함.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
