### PR TITLE
게시물 1개 삭제 api 리팩토링

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/feed/FeedController.java
+++ b/src/main/java/com/devtraces/arterest/controller/feed/FeedController.java
@@ -7,6 +7,7 @@ import com.devtraces.arterest.controller.feed.dto.response.FeedUpdateResponse;
 import com.devtraces.arterest.service.feed.FeedDeleteService;
 import com.devtraces.arterest.service.feed.FeedReadService;
 import com.devtraces.arterest.service.feed.FeedService;
+import com.devtraces.arterest.service.feed.application.FeedDeleteApplication;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,7 +28,7 @@ public class FeedController {
 
     private final FeedService feedService;
     private final FeedReadService feedreadService;
-    private final FeedDeleteService feedDeleteService;
+    private final FeedDeleteApplication feedDeleteApplication;
 
     @PostMapping
     public ApiSuccessResponse<FeedCreateResponse> createFeed(
@@ -81,7 +82,7 @@ public class FeedController {
     public ApiSuccessResponse<?> deleteFeed(
         @AuthenticationPrincipal Long userId, @PathVariable Long feedId
     ){
-        feedDeleteService.deleteFeed(userId, feedId);
+        feedDeleteApplication.deleteFeed(userId, feedId);
         return ApiSuccessResponse.NO_DATA_RESPONSE;
     }
 

--- a/src/main/java/com/devtraces/arterest/service/bookmark/BookmarkService.java
+++ b/src/main/java/com/devtraces/arterest/service/bookmark/BookmarkService.java
@@ -55,4 +55,9 @@ public class BookmarkService {
 	public void deleteBookmark(Long userId, Long feedId) {
 		bookmarkRepository.deleteByUserIdAndFeedId(userId, feedId);
 	}
+
+	@Transactional
+	public void deleteAllFeedRelatedBookmark(Long feedId){
+		bookmarkRepository.deleteAllByFeedId(feedId);
+	}
 }

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
@@ -70,7 +70,7 @@ public class FeedDeleteService {
 		likeRepository.deleteAllByFeedId(feedId);*/
 
 		// 북마크 테이블에서 정보 모두 삭제
-		bookmarkRepository.deleteAllByFeedId(feedId);
+		// bookmarkRepository.deleteAllByFeedId(feedId);
 
 		// 대댓글 삭제
 		for(Reply reply : feed.getReplyList()){

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
@@ -30,26 +30,24 @@ public class FeedDeleteService {
 	private final LikeRepository likeRepository;
 	private final BookmarkRepository bookmarkRepository;
 	private final LikeNumberCacheRepository likeNumberCacheRepository;
-	private final S3Service s3Service;
 	private final FeedHashtagMapRepository feedHashtagMapRepository;
 	private final HashtagRepository hashtagRepository;
 
-	// TODO 스프링 @Async를 사용해서 비동기 멀티 스레딩으로 처리하면 응답지연시간 최소화 가능.
 	@Transactional
 	public void deleteFeed(Long userId, Long feedId){
-		Feed feed = feedRepository.findById(feedId).orElseThrow(
+		/*Feed feed = feedRepository.findById(feedId).orElseThrow(
 			() -> BaseException.FEED_NOT_FOUND
 		);
 		if(!Objects.equals(feed.getUser().getId(), userId)){
 			throw BaseException.USER_INFO_NOT_MATCH;
-		}
+		}*/
 
-		// S3에 올려놨던 사진들을 전부 삭제한다.
+		/*// S3에 올려놨던 사진들을 전부 삭제한다.
 		if(!feed.getImageUrls().equals("")){
 			for(String deleteTargetUrl : feed.getImageUrls().split(",")){
 				s3Service.deleteImage(deleteTargetUrl);
 			}
-		}
+		}*/
 		
 		// 삭제될 FeedHashtagMap 데이터 목록을 가져옴.
 		List<FeedHashtagMap> feedHashtagMapList = feedHashtagMapRepository.findByFeed(feed);

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
@@ -49,14 +49,14 @@ public class FeedDeleteService {
 			}
 		}*/
 		
-		// 삭제될 FeedHashtagMap 데이터 목록을 가져옴.
+		/*// 삭제될 FeedHashtagMap 데이터 목록을 가져옴.
 		List<FeedHashtagMap> feedHashtagMapList = feedHashtagMapRepository.findByFeed(feed);
 		
 		// FeedHashtagMap 테이블에서 관련 정보 모두 삭제.
 		feedHashtagMapRepository.deleteAllByFeedId(feedId);
 
 		// 사용되지 않는 Hashtag 삭제.
-		deleteNotUsingHashtag(feedHashtagMapList);
+		deleteNotUsingHashtag(feedHashtagMapList);*/
 
 		// 레디스에서 좋아요 개수 기록한 키-밸류 쌍 삭제.
 		likeNumberCacheRepository.deleteLikeNumberInfo(feedId);
@@ -83,16 +83,6 @@ public class FeedDeleteService {
 		);
 
 		// 피드 삭제.
-		feedRepository.deleteById(feedId);
-	}
-
-	void deleteNotUsingHashtag(List<FeedHashtagMap> feedHashtagMapList){
-		// 삭제된 FeedHashtagMap의 feedId에 매핑된 hashtagId가 더이상 FeedHashtagMap에 존재하지 않을 경우,
-		// 해당 hastagId를 Hashtag 테이블에서 삭제함.
-		for (FeedHashtagMap feedHashtagMap : feedHashtagMapList) {
-			if(!feedHashtagMapRepository.existsByHashtag(feedHashtagMap.getHashtag())){
-				hashtagRepository.deleteById(feedHashtagMap.getHashtag().getId());
-			}
-		}
+		// feedRepository.deleteById(feedId);
 	}
 }

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
@@ -34,6 +34,11 @@ public class FeedDeleteService {
 	private final HashtagRepository hashtagRepository;
 
 	@Transactional
+	public void deleteFeedEntity(Long feedId){
+		feedRepository.deleteById(feedId);
+	}
+
+	@Transactional
 	public void deleteFeed(Long userId, Long feedId){
 		/*Feed feed = feedRepository.findById(feedId).orElseThrow(
 			() -> BaseException.FEED_NOT_FOUND

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
@@ -1,22 +1,6 @@
 package com.devtraces.arterest.service.feed;
 
-import com.devtraces.arterest.common.exception.BaseException;
-import com.devtraces.arterest.model.bookmark.BookmarkRepository;
-import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.feed.FeedRepository;
-import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMap;
-import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMapRepository;
-import com.devtraces.arterest.model.hashtag.HashtagRepository;
-import com.devtraces.arterest.model.like.LikeRepository;
-import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
-import com.devtraces.arterest.model.reply.Reply;
-import com.devtraces.arterest.model.reply.ReplyRepository;
-import com.devtraces.arterest.model.rereply.Rereply;
-import com.devtraces.arterest.model.rereply.RereplyRepository;
-import com.devtraces.arterest.service.s3.S3Service;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,69 +9,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FeedDeleteService {
 	private final FeedRepository feedRepository;
-	private final ReplyRepository replyRepository;
-	private final RereplyRepository rereplyRepository;
-	private final LikeRepository likeRepository;
-	private final BookmarkRepository bookmarkRepository;
-	private final LikeNumberCacheRepository likeNumberCacheRepository;
-	private final FeedHashtagMapRepository feedHashtagMapRepository;
-	private final HashtagRepository hashtagRepository;
 
 	@Transactional
 	public void deleteFeedEntity(Long feedId){
 		feedRepository.deleteById(feedId);
-	}
-
-	@Transactional
-	public void deleteFeed(Long userId, Long feedId){
-		/*Feed feed = feedRepository.findById(feedId).orElseThrow(
-			() -> BaseException.FEED_NOT_FOUND
-		);
-		if(!Objects.equals(feed.getUser().getId(), userId)){
-			throw BaseException.USER_INFO_NOT_MATCH;
-		}*/
-
-		/*// S3에 올려놨던 사진들을 전부 삭제한다.
-		if(!feed.getImageUrls().equals("")){
-			for(String deleteTargetUrl : feed.getImageUrls().split(",")){
-				s3Service.deleteImage(deleteTargetUrl);
-			}
-		}*/
-		
-		/*// 삭제될 FeedHashtagMap 데이터 목록을 가져옴.
-		List<FeedHashtagMap> feedHashtagMapList = feedHashtagMapRepository.findByFeed(feed);
-		
-		// FeedHashtagMap 테이블에서 관련 정보 모두 삭제.
-		feedHashtagMapRepository.deleteAllByFeedId(feedId);
-
-		// 사용되지 않는 Hashtag 삭제.
-		deleteNotUsingHashtag(feedHashtagMapList);*/
-
-		/*// 레디스에서 좋아요 개수 기록한 키-밸류 쌍 삭제.
-		likeNumberCacheRepository.deleteLikeNumberInfo(feedId);
-
-		// 좋아요 테이블에서 정보 모두 삭제
-		likeRepository.deleteAllByFeedId(feedId);*/
-
-		// 북마크 테이블에서 정보 모두 삭제
-		// bookmarkRepository.deleteAllByFeedId(feedId);
-
-		// 대댓글 삭제
-		/*for(Reply reply : feed.getReplyList()){
-			if(reply.getRereplyList().size() > 0){
-				rereplyRepository.deleteAllByIdIn(
-					reply.getRereplyList().stream().map(Rereply::getId)
-						.collect(Collectors.toList())
-				);
-			}
-		}*/
-
-		// 댓글 삭제
-		/*replyRepository.deleteAllByIdIn(
-			feed.getReplyList().stream().map(Reply::getId).collect(Collectors.toList())
-		);*/
-
-		// 피드 삭제.
-		// feedRepository.deleteById(feedId);
 	}
 }

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
@@ -63,11 +63,11 @@ public class FeedDeleteService {
 		// 사용되지 않는 Hashtag 삭제.
 		deleteNotUsingHashtag(feedHashtagMapList);*/
 
-		// 레디스에서 좋아요 개수 기록한 키-밸류 쌍 삭제.
+		/*// 레디스에서 좋아요 개수 기록한 키-밸류 쌍 삭제.
 		likeNumberCacheRepository.deleteLikeNumberInfo(feedId);
 
 		// 좋아요 테이블에서 정보 모두 삭제
-		likeRepository.deleteAllByFeedId(feedId);
+		likeRepository.deleteAllByFeedId(feedId);*/
 
 		// 북마크 테이블에서 정보 모두 삭제
 		bookmarkRepository.deleteAllByFeedId(feedId);

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
@@ -73,14 +73,14 @@ public class FeedDeleteService {
 		// bookmarkRepository.deleteAllByFeedId(feedId);
 
 		// 대댓글 삭제
-		for(Reply reply : feed.getReplyList()){
+		/*for(Reply reply : feed.getReplyList()){
 			if(reply.getRereplyList().size() > 0){
 				rereplyRepository.deleteAllByIdIn(
 					reply.getRereplyList().stream().map(Rereply::getId)
 						.collect(Collectors.toList())
 				);
 			}
-		}
+		}*/
 
 		// 댓글 삭제
 		replyRepository.deleteAllByIdIn(

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedDeleteService.java
@@ -83,9 +83,9 @@ public class FeedDeleteService {
 		}*/
 
 		// 댓글 삭제
-		replyRepository.deleteAllByIdIn(
+		/*replyRepository.deleteAllByIdIn(
 			feed.getReplyList().stream().map(Reply::getId).collect(Collectors.toList())
-		);
+		);*/
 
 		// 피드 삭제.
 		// feedRepository.deleteById(feedId);

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedReadService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedReadService.java
@@ -57,6 +57,13 @@ public class FeedReadService {
 		);
 	}
 
+	@Transactional(readOnly = true)
+	public Feed getOneFeedEntity(Long feedId){
+		return feedRepository.findById(feedId).orElseThrow(
+			() -> BaseException.FEED_NOT_FOUND
+		);
+	}
+
 	// 피드 별 좋아요 개수는 레디스를 먼저 보게 만들고, 그게 불가능 할때만 Like 테이블에서 찾도록 한다.
 	private Long getOrCacheLikeNumber(Feed feed) {
 		Long likeNumber = likeNumberCacheRepository.getFeedLikeNumber(feed.getId());

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
@@ -1,6 +1,5 @@
 package com.devtraces.arterest.service.feed;
 
-import com.devtraces.arterest.common.constant.CommonConstant;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.controller.feed.dto.response.FeedCreateResponse;
 import com.devtraces.arterest.controller.feed.dto.response.FeedUpdateResponse;
@@ -13,6 +12,7 @@ import com.devtraces.arterest.model.hashtag.HashtagRepository;
 import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
 import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
+import com.devtraces.arterest.service.hashtag.HashtagService;
 import com.devtraces.arterest.service.s3.S3Service;
 import java.util.HashSet;
 import java.util.List;
@@ -35,7 +35,7 @@ public class FeedService {
     private final HashtagRepository hashtagRepository;
     private final FeedHashtagMapRepository feedHashtagMapRepository;
 
-    private final FeedDeleteService feedDeleteService;
+    private final HashtagService hashtagService;
 
     @Transactional
     public FeedCreateResponse createFeed(
@@ -149,7 +149,7 @@ public class FeedService {
         feedHashtagMapRepository.deleteAllByFeedId(feedId);
 
         // 사용되지 않는 Hashtag 삭제.
-        feedDeleteService.deleteNotUsingHashtag(feedHashtagMapList);
+        hashtagService.deleteNotUsingHashtag(feedHashtagMapList);
 
         // 그 후 입력 받은 값에 따라서 새롭게 저장한다.
         if(hashtagList != null){

--- a/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
@@ -3,6 +3,9 @@ package com.devtraces.arterest.service.feed.application;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
+import com.devtraces.arterest.service.feed.FeedDeleteService;
+import com.devtraces.arterest.service.feed.FeedReadService;
 import com.devtraces.arterest.service.hashtag.HashtagService;
 import com.devtraces.arterest.service.s3.S3Service;
 import java.util.Objects;
@@ -14,16 +17,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FeedDeleteApplication {
 
-    private final FeedRepository feedRepository;
+    private final FeedDeleteService feedDeleteService;
+    private final FeedReadService feedReadService;
     private final S3Service s3Service;
     private final HashtagService hashtagService;
 
     // TODO 스프링 @Async를 사용해서 비동기 멀티 스레딩으로 처리하면 응답지연시간 최소화 가능.
     @Transactional
     public void deleteFeed(Long userId, Long feedId){
-        Feed feed = feedRepository.findById(feedId).orElseThrow(
-            () -> BaseException.FEED_NOT_FOUND
-        );
+        Feed feed = feedReadService.getOneFeedEntity(feedId);
+
         if(!Objects.equals(feed.getUser().getId(), userId)){
             throw BaseException.USER_INFO_NOT_MATCH;
         }
@@ -39,7 +42,7 @@ public class FeedDeleteApplication {
         hashtagService.deleteHashtagRelatedData(feed);
 
         // 피드 삭제.
-        feedRepository.deleteById(feedId);
+        feedDeleteService.deleteFeedEntity(feedId);
     }
 
 }

--- a/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
@@ -7,6 +7,7 @@ import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
 import com.devtraces.arterest.service.feed.FeedDeleteService;
 import com.devtraces.arterest.service.feed.FeedReadService;
 import com.devtraces.arterest.service.hashtag.HashtagService;
+import com.devtraces.arterest.service.like.LikeService;
 import com.devtraces.arterest.service.s3.S3Service;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class FeedDeleteApplication {
     private final FeedReadService feedReadService;
     private final S3Service s3Service;
     private final HashtagService hashtagService;
+    private final LikeService likeService;
 
     // TODO 스프링 @Async를 사용해서 비동기 멀티 스레딩으로 처리하면 응답지연시간 최소화 가능.
     @Transactional
@@ -40,6 +42,9 @@ public class FeedDeleteApplication {
 
         // 해시태그 관련 정보들을 전부 삭제한다.
         hashtagService.deleteHashtagRelatedData(feed);
+
+        // 좋아요 관련 정보들을 전부 삭제한다.
+        likeService.deleteLikeRelatedData(feedId);
 
         // 피드 삭제.
         feedDeleteService.deleteFeedEntity(feedId);

--- a/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
@@ -2,8 +2,6 @@ package com.devtraces.arterest.service.feed.application;
 
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.model.feed.Feed;
-import com.devtraces.arterest.model.feed.FeedRepository;
-import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
 import com.devtraces.arterest.service.bookmark.BookmarkService;
 import com.devtraces.arterest.service.feed.FeedDeleteService;
 import com.devtraces.arterest.service.feed.FeedReadService;

--- a/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
@@ -1,12 +1,39 @@
 package com.devtraces.arterest.service.feed.application;
 
+import com.devtraces.arterest.common.exception.BaseException;
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.service.s3.S3Service;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class FeedDeleteApplication {
 
+    private final FeedRepository feedRepository;
+    private final S3Service s3Service;
 
+    // TODO 스프링 @Async를 사용해서 비동기 멀티 스레딩으로 처리하면 응답지연시간 최소화 가능.
+    @Transactional
+    public void deleteFeed(Long userId, Long feedId){
+        Feed feed = feedRepository.findById(feedId).orElseThrow(
+            () -> BaseException.FEED_NOT_FOUND
+        );
+        if(!Objects.equals(feed.getUser().getId(), userId)){
+            throw BaseException.USER_INFO_NOT_MATCH;
+        }
+
+        // S3에 올려놨던 사진들을 전부 삭제한다.
+        if(!feed.getImageUrls().equals("")){
+            for(String deleteTargetUrl : feed.getImageUrls().split(",")){
+                s3Service.deleteImage(deleteTargetUrl);
+            }
+        }
+
+
+    }
 
 }

--- a/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
@@ -3,6 +3,7 @@ package com.devtraces.arterest.service.feed.application;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.service.hashtag.HashtagService;
 import com.devtraces.arterest.service.s3.S3Service;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ public class FeedDeleteApplication {
 
     private final FeedRepository feedRepository;
     private final S3Service s3Service;
+    private final HashtagService hashtagService;
 
     // TODO 스프링 @Async를 사용해서 비동기 멀티 스레딩으로 처리하면 응답지연시간 최소화 가능.
     @Transactional
@@ -33,7 +35,11 @@ public class FeedDeleteApplication {
             }
         }
 
+        // 해시태그 관련 정보들을 전부 삭제한다.
+        hashtagService.deleteHashtagRelatedData(feed);
 
+        // 피드 삭제.
+        feedRepository.deleteById(feedId);
     }
 
 }

--- a/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
@@ -4,6 +4,7 @@ import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.feed.FeedRepository;
 import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
+import com.devtraces.arterest.service.bookmark.BookmarkService;
 import com.devtraces.arterest.service.feed.FeedDeleteService;
 import com.devtraces.arterest.service.feed.FeedReadService;
 import com.devtraces.arterest.service.hashtag.HashtagService;
@@ -23,6 +24,7 @@ public class FeedDeleteApplication {
     private final S3Service s3Service;
     private final HashtagService hashtagService;
     private final LikeService likeService;
+    private final BookmarkService bookmarkService;
 
     // TODO 스프링 @Async를 사용해서 비동기 멀티 스레딩으로 처리하면 응답지연시간 최소화 가능.
     @Transactional
@@ -46,7 +48,10 @@ public class FeedDeleteApplication {
         // 좋아요 관련 정보들을 전부 삭제한다.
         likeService.deleteLikeRelatedData(feedId);
 
-        // 피드 삭제.
+        // 북마크 테이블에서 정보 모두 삭제.
+        bookmarkService.deleteAllFeedRelatedBookmark(feedId);
+
+        // 마지막으로 피드 삭제.
         feedDeleteService.deleteFeedEntity(feedId);
     }
 

--- a/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
@@ -1,0 +1,12 @@
+package com.devtraces.arterest.service.feed.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeedDeleteApplication {
+
+
+
+}

--- a/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
@@ -9,6 +9,7 @@ import com.devtraces.arterest.service.feed.FeedDeleteService;
 import com.devtraces.arterest.service.feed.FeedReadService;
 import com.devtraces.arterest.service.hashtag.HashtagService;
 import com.devtraces.arterest.service.like.LikeService;
+import com.devtraces.arterest.service.rereply.RereplyService;
 import com.devtraces.arterest.service.s3.S3Service;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class FeedDeleteApplication {
     private final HashtagService hashtagService;
     private final LikeService likeService;
     private final BookmarkService bookmarkService;
+    private final RereplyService rereplyService;
 
     // TODO 스프링 @Async를 사용해서 비동기 멀티 스레딩으로 처리하면 응답지연시간 최소화 가능.
     @Transactional
@@ -50,6 +52,9 @@ public class FeedDeleteApplication {
 
         // 북마크 테이블에서 정보 모두 삭제.
         bookmarkService.deleteAllFeedRelatedBookmark(feedId);
+
+        // 대댓글 삭제
+        rereplyService.deleteAllFeedRelatedRereply(feed);
 
         // 마지막으로 피드 삭제.
         feedDeleteService.deleteFeedEntity(feedId);

--- a/src/main/java/com/devtraces/arterest/service/hashtag/HashtagService.java
+++ b/src/main/java/com/devtraces/arterest/service/hashtag/HashtagService.java
@@ -1,0 +1,40 @@
+package com.devtraces.arterest.service.hashtag;
+
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMap;
+import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMapRepository;
+import com.devtraces.arterest.model.hashtag.HashtagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+    private final FeedHashtagMapRepository feedHashtagMapRepository;
+
+    @Transactional
+    public void deleteHashtagRelatedData(Feed feed){
+        // 삭제될 FeedHashtagMap 데이터 목록을 가져옴.
+        List<FeedHashtagMap> feedHashtagMapList = feedHashtagMapRepository.findByFeed(feed);
+
+        // FeedHashtagMap 테이블에서 관련 정보 모두 삭제.
+        feedHashtagMapRepository.deleteAllByFeedId(feed.getId());
+
+        // 사용되지 않는 Hashtag 삭제.
+        deleteNotUsingHashtag(feedHashtagMapList);
+    }
+
+    void deleteNotUsingHashtag(List<FeedHashtagMap> feedHashtagMapList){
+        // 삭제된 FeedHashtagMap의 feedId에 매핑된 hashtagId가 더이상 FeedHashtagMap에 존재하지 않을 경우,
+        // 해당 hastagId를 Hashtag 테이블에서 삭제함.
+        for (FeedHashtagMap feedHashtagMap : feedHashtagMapList) {
+            if(!feedHashtagMapRepository.existsByHashtag(feedHashtagMap.getHashtag())){
+                hashtagRepository.deleteById(feedHashtagMap.getHashtag().getId());
+            }
+        }
+    }
+}

--- a/src/main/java/com/devtraces/arterest/service/hashtag/HashtagService.java
+++ b/src/main/java/com/devtraces/arterest/service/hashtag/HashtagService.java
@@ -28,7 +28,7 @@ public class HashtagService {
         deleteNotUsingHashtag(feedHashtagMapList);
     }
 
-    void deleteNotUsingHashtag(List<FeedHashtagMap> feedHashtagMapList){
+    public void deleteNotUsingHashtag(List<FeedHashtagMap> feedHashtagMapList){
         // 삭제된 FeedHashtagMap의 feedId에 매핑된 hashtagId가 더이상 FeedHashtagMap에 존재하지 않을 경우,
         // 해당 hastagId를 Hashtag 테이블에서 삭제함.
         for (FeedHashtagMap feedHashtagMap : feedHashtagMapList) {

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -67,6 +67,12 @@ public class LikeService {
             .map(LikeResponse::from).collect(Collectors.toList());
     }
 
+    @Transactional
+    public void deleteLikeRelatedData(Long feedId){
+        likeNumberCacheRepository.deleteLikeNumberInfo(feedId);
+        likeRepository.deleteAllByFeedId(feedId);
+    }
+
     private void validateFeedExistence(Long feedId) {
         if(!feedRepository.existsById(feedId)){
             throw BaseException.FEED_NOT_FOUND;

--- a/src/main/java/com/devtraces/arterest/service/reply/ReplyService.java
+++ b/src/main/java/com/devtraces/arterest/service/reply/ReplyService.java
@@ -95,6 +95,13 @@ public class ReplyService {
         replyRepository.deleteById(replyId);
     }
 
+    @Transactional
+    public void deleteAllFeedRelatedReply(Feed feed){
+        replyRepository.deleteAllByIdIn(
+            feed.getReplyList().stream().map(Reply::getId).collect(Collectors.toList())
+        );
+    }
+
     private static void validateReplyRequest(ReplyRequest replyRequest) {
         if(replyRequest.getContent() == null || replyRequest.getContent().equals("")){
             throw BaseException.NULL_AND_EMPTY_STRING_NOT_ALLOWED;

--- a/src/main/java/com/devtraces/arterest/service/rereply/RereplyService.java
+++ b/src/main/java/com/devtraces/arterest/service/rereply/RereplyService.java
@@ -2,6 +2,7 @@ package com.devtraces.arterest.service.rereply;
 
 import com.devtraces.arterest.common.constant.CommonConstant;
 import com.devtraces.arterest.common.exception.BaseException;
+import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.reply.Reply;
 import com.devtraces.arterest.model.reply.ReplyRepository;
 import com.devtraces.arterest.model.rereply.Rereply;
@@ -80,6 +81,18 @@ public class RereplyService {
             throw BaseException.USER_INFO_NOT_MATCH;
         }
         rereplyRepository.deleteById(rereplyId);
+    }
+
+    @Transactional
+    public void deleteAllFeedRelatedRereply(Feed feed){
+        for(Reply reply : feed.getReplyList()){
+            if(reply.getRereplyList().size() > 0){
+                rereplyRepository.deleteAllByIdIn(
+                    reply.getRereplyList().stream().map(Rereply::getId)
+                        .collect(Collectors.toList())
+                );
+            }
+        }
     }
 
     private void validateRereplyRequest(RereplyRequest rereplyRequest) {

--- a/src/test/java/com/devtraces/arterest/service/bookmark/BookmarkServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/bookmark/BookmarkServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -134,5 +135,17 @@ class BookmarkServiceTest {
 
 		// then
 		verify(bookmarkRepository, times(1)).deleteByUserIdAndFeedId(1L, 2L);
+	}
+
+	@Test
+	void testDeleteAllFeedRelatedBookmark() {
+		// given
+		doNothing().when(bookmarkRepository).deleteAllByFeedId(1L);
+
+		// when
+		bookmarkService.deleteAllFeedRelatedBookmark(1L);
+
+		// then
+		verify(bookmarkRepository, times(1)).deleteAllByFeedId(1L);
 	}
 }

--- a/src/test/java/com/devtraces/arterest/service/feed/FeedDeleteServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/FeedDeleteServiceTest.java
@@ -40,20 +40,6 @@ class FeedDeleteServiceTest {
 
     @Mock
     private FeedRepository feedRepository;
-    @Mock
-    private ReplyRepository replyRepository;
-    @Mock
-    private RereplyRepository rereplyRepository;
-    @Mock
-    private LikeRepository likeRepository;
-    @Mock
-    private BookmarkRepository bookmarkRepository;
-    @Mock
-    private LikeNumberCacheRepository likeNumberCacheRepository;
-    @Mock
-    private S3Service s3Service;
-    @Mock
-    private FeedHashtagMapRepository feedHashtagMapRepository;
     @InjectMocks
     private FeedDeleteService feedDeleteService;
 
@@ -61,95 +47,13 @@ class FeedDeleteServiceTest {
     @DisplayName("피드 1개 제거")
     void successDeleteFeed(){
         // given
-        User user = User.builder()
-            .id(1L)
-            .build();
-
-        Rereply rereply = Rereply.builder()
-            .id(1L)
-            .build();
-
-        Reply reply = Reply.builder()
-            .id(1L)
-            .rereplyList(new ArrayList<>())
-            .build();
-        reply.getRereplyList().add(rereply);
-
-        Feed feed = Feed.builder()
-            .id(1L)
-            .replyList(new ArrayList<>())
-            .user(user)
-            .imageUrls("imageUrl,")
-            .build();
-        feed.getReplyList().add(reply);
-
-        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
-
-        doNothing().when(s3Service).deleteImage(anyString());
-        doNothing().when(feedHashtagMapRepository).deleteAllByFeedId(anyLong());
-        doNothing().when(likeNumberCacheRepository).deleteLikeNumberInfo(anyLong());
-        doNothing().when(likeRepository).deleteAllByFeedId(anyLong());
-        doNothing().when(bookmarkRepository).deleteAllByFeedId(anyLong());
-        doNothing().when(rereplyRepository).deleteAllByIdIn(anyList());
-        doNothing().when(replyRepository).deleteAllByIdIn(anyList());
         doNothing().when(feedRepository).deleteById(anyLong());
 
         // when
-        feedDeleteService.deleteFeed(1L, 1L);
-
-        List<Long> longList = new ArrayList<>();
-        longList.add(1L);
+        feedDeleteService.deleteFeedEntity(1L);
 
         // then
-        verify(s3Service, times(1)).deleteImage("imageUrl");
-        verify(feedHashtagMapRepository, times(1)).deleteAllByFeedId(1L);
-        verify(likeNumberCacheRepository, times(1)).deleteLikeNumberInfo(1L);
-        verify(likeRepository, times(1)).deleteAllByFeedId(1L);
-        verify(bookmarkRepository, times(1)).deleteAllByFeedId(1L);
-        verify(rereplyRepository, times(1)).deleteAllByIdIn(longList);
-        verify(replyRepository, times(1)).deleteAllByIdIn(longList);
-        verify(feedRepository).deleteById(anyLong());
-    }
-
-    @Test
-    @DisplayName("게시물 삭제 실패 - 삭제 대상 게시물을 찾을 수 없음.")
-    void failedDeleteFeedFeedNotFound(){
-        // given
-        given(feedRepository.findById(anyLong())).willReturn(Optional.empty());
-
-        // when
-        BaseException exception = assertThrows(
-            BaseException.class ,
-            () -> feedDeleteService.deleteFeed(1L, 1L)
-        );
-
-        // then
-        assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
-    }
-
-    @Test
-    @DisplayName("게시물 삭제 실패 - 유저 정보가 게시물 작성자 정보와 일치하지 않음.")
-    void failedDeleteFeedUserInfoNotMatch(){
-        // given
-        User user = User.builder()
-            .id(2L)
-            .build();
-
-        Feed feed = Feed.builder()
-            .id(1L)
-            .user(user)
-            .build();
-
-        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
-
-        // when
-        BaseException exception = assertThrows(
-            BaseException.class ,
-            () -> feedDeleteService.deleteFeed(1L, 1L)
-        );
-
-        // then
-        assertEquals(ErrorCode.USER_INFO_NOT_MATCH, exception.getErrorCode());
+        verify(feedRepository, times(1)).deleteById(anyLong());
     }
 
 }

--- a/src/test/java/com/devtraces/arterest/service/feed/FeedReadServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/FeedReadServiceTest.java
@@ -1,11 +1,14 @@
 package com.devtraces.arterest.service.feed;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.devtraces.arterest.common.exception.BaseException;
+import com.devtraces.arterest.common.exception.ErrorCode;
 import com.devtraces.arterest.controller.feed.dto.response.FeedResponse;
 import com.devtraces.arterest.model.bookmark.Bookmark;
 import com.devtraces.arterest.model.bookmark.BookmarkRepository;
@@ -49,7 +52,7 @@ class FeedReadServiceTest {
     @Test
     @DisplayName("피드 리스트 읽기 성공 - 레디스에서 좋아요 개수 획득 성공한 경우.")
     void successGetFeedListRedisServerAvailable(){
-        //given
+        // given
         Reply reply = Reply.builder()
             .id(1L)
             .content("this is reply")
@@ -80,12 +83,12 @@ class FeedReadServiceTest {
         given(feedRepository.findAllByUserIdOrderByCreatedAtDesc(1L, PageRequest.of(0, 10))).willReturn(slice);
         given(userRepository.findByNickname("dongvin99")).willReturn(Optional.of(user));
         given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(0L);
-        //given(likeRepository.countByFeedId(1L)).willReturn(0L);
+        // given(likeRepository.countByFeedId(1L)).willReturn(0L);
 
-        //when
+        // when
         List<FeedResponse> feedResponseList = feedReadService.getFeedResponseList(1L, "dongvin99", 0, 10);
 
-        //then
+        // then
         verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
         verify(feedRepository, times(1)).findAllByUserIdOrderByCreatedAtDesc(1L, PageRequest.of(0, 10));
         assertEquals(feedResponseList.size(), 1);
@@ -94,7 +97,7 @@ class FeedReadServiceTest {
     @Test
     @DisplayName("피드 리스트 읽기 성공 - 레디스에서 좋아요 개수 획득에 실패한 경우.")
     void successGetFeedListRedisServerNotAvailable(){
-        //given
+        // given
         Reply reply = Reply.builder()
             .id(1L)
             .content("this is reply")
@@ -128,10 +131,10 @@ class FeedReadServiceTest {
         given(likeRepository.countByFeedId(1L)).willReturn(0L);
         doNothing().when(likeNumberCacheRepository).setLikeNumber(1L, 0L);
 
-        //when
+        // when
         List<FeedResponse> feedResponseList = feedReadService.getFeedResponseList(1L, "dongvin99", 0, 10);
 
-        //then
+        // then
         verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
         verify(likeRepository, times(1)).countByFeedId(1L);
         verify(likeNumberCacheRepository, times(1)).setLikeNumber(1L, 0L);
@@ -142,7 +145,7 @@ class FeedReadServiceTest {
     @Test
     @DisplayName("피드 1개 읽기 성공 - 레디스에서 좋아요 개수 획득에 성공한 경우.")
     void successGetOneFeedRedisServerAvailable(){
-        //given
+        // given
         Reply reply = Reply.builder()
             .id(1L)
             .content("this is reply")
@@ -173,10 +176,10 @@ class FeedReadServiceTest {
         given(feedRepository.findById(1L)).willReturn(Optional.of(feed));
         given(likeNumberCacheRepository.getFeedLikeNumber(1L)).willReturn(0L);
 
-        //when
+        // when
         FeedResponse feedResponse = feedReadService.getOneFeed(1L, 1L);
 
-        //then
+        // then
         verify(likeRepository, times(1)).findAllByUserId(1L);
         verify(bookmarkRepository, times(1)).findAllByUserId(1L);
         verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
@@ -187,7 +190,7 @@ class FeedReadServiceTest {
     @Test
     @DisplayName("피드 1개 읽기 성공 - 레디스에서 좋아요 개수 획득에 실패한 경우")
     void successGetOneFeedRedisServerNotAvailable(){
-        //given
+        // given
         Reply reply = Reply.builder()
             .id(1L)
             .content("this is reply")
@@ -220,10 +223,10 @@ class FeedReadServiceTest {
         given(likeRepository.countByFeedId(1L)).willReturn(0L);
         doNothing().when(likeNumberCacheRepository).setLikeNumber(1L, 0L);
 
-        //when
+        // when
         FeedResponse feedResponse = feedReadService.getOneFeed(1L, 1L);
 
-        //then
+        // then
         verify(likeRepository, times(1)).findAllByUserId(1L);
         verify(bookmarkRepository, times(1)).findAllByUserId(1L);
         verify(likeNumberCacheRepository, times(1)).getFeedLikeNumber(1L);
@@ -231,6 +234,43 @@ class FeedReadServiceTest {
         verify(likeNumberCacheRepository, times(1)).setLikeNumber(1L, 0L);
         verify(feedRepository, times(1)).findById(1L);
         assertEquals(feedResponse.getFeedId(), 1L);
+    }
+
+    @Test
+    @DisplayName("게시물 엔티티 1개 찾기 성공")
+    void successGetOneFeedEntity(){
+        // given
+        Feed feed = Feed.builder()
+            .id(1L)
+            .build();
+
+        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
+
+        // when
+        feedReadService.getOneFeedEntity(1L);
+
+        // then
+        verify(feedRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("게시물 엔티티 1개 찾기 실패 - 게시물이 존재하지 않음")
+    void failedGetOneFeedEntityFeedNotFound(){
+        // given
+        Feed feed = Feed.builder()
+            .id(1L)
+            .build();
+
+        given(feedRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when
+        BaseException exception = assertThrows(
+            BaseException.class ,
+            () -> feedReadService.getOneFeedEntity(1L)
+        );
+
+        // then
+        assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
     }
 
 }

--- a/src/test/java/com/devtraces/arterest/service/feed/FeedServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/FeedServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.devtraces.arterest.common.constant.CommonConstant;
+import com.devtraces.arterest.service.hashtag.HashtagService;
 import com.devtraces.arterest.service.s3.S3Service;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.exception.ErrorCode;
@@ -52,7 +53,7 @@ class FeedServiceTest {
     @Mock
     private FeedHashtagMapRepository feedHashtagMapRepository;
     @Mock
-    private FeedDeleteService feedDeleteService;
+    private HashtagService hashtagService;
     @InjectMocks
     private FeedService feedService;
 
@@ -305,7 +306,7 @@ class FeedServiceTest {
         doNothing().when(s3Service).deleteImage("urlString");
         given(s3Service.uploadImage(multipartFile)).willReturn("urlString");
         doNothing().when(feedHashtagMapRepository).deleteAllByFeedId(1L);
-        doNothing().when(feedDeleteService).deleteNotUsingHashtag(anyList());
+        doNothing().when(hashtagService).deleteNotUsingHashtag(anyList());
         given(hashtagRepository.findByHashtagString("#potato")).willReturn(Optional.of(hashtagEntity));
         given(feedHashtagMapRepository.save(any())).willReturn(feedHashtagMap);
         given(feedRepository.save(any())).willReturn(feed);
@@ -318,7 +319,7 @@ class FeedServiceTest {
         verify(s3Service, times(1)).deleteImage(any());
         verify(s3Service, times(1)).uploadImage(any());
         verify(feedHashtagMapRepository, times(1)).deleteAllByFeedId(1L);
-        verify(feedDeleteService, times(1)).deleteNotUsingHashtag(anyList());
+        verify(hashtagService, times(1)).deleteNotUsingHashtag(anyList());
         verify(hashtagRepository, times(1)).findByHashtagString(anyString());
         verify(hashtagRepository, times(1)).findByHashtagString(anyString());
         verify(feedRepository, times(1)).save(any());
@@ -370,7 +371,7 @@ class FeedServiceTest {
         doNothing().when(s3Service).deleteImage("urlString");
         given(s3Service.uploadImage(multipartFile)).willReturn("urlString");
         doNothing().when(feedHashtagMapRepository).deleteAllByFeedId(1L);
-        doNothing().when(feedDeleteService).deleteNotUsingHashtag(anyList());
+        doNothing().when(hashtagService).deleteNotUsingHashtag(anyList());
         given(hashtagRepository.findByHashtagString("#potato")).willReturn(Optional.empty());
         given(hashtagRepository.save(any())).willReturn(hashtagEntity);
         given(feedHashtagMapRepository.save(any())).willReturn(feedHashtagMap);
@@ -384,7 +385,7 @@ class FeedServiceTest {
         verify(s3Service, times(1)).deleteImage(any());
         verify(s3Service, times(1)).uploadImage(any());
         verify(feedHashtagMapRepository, times(1)).deleteAllByFeedId(1L);
-        verify(feedDeleteService, times(1)).deleteNotUsingHashtag(anyList());
+        verify(hashtagService, times(1)).deleteNotUsingHashtag(anyList());
         verify(hashtagRepository, times(1)).findByHashtagString(anyString());
         verify(hashtagRepository, times(1)).save(any());
         verify(feedHashtagMapRepository, times(1)).save(any());

--- a/src/test/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplicationTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplicationTest.java
@@ -1,7 +1,17 @@
 package com.devtraces.arterest.service.feed.application;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import com.devtraces.arterest.common.exception.BaseException;
+import com.devtraces.arterest.common.exception.ErrorCode;
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.service.bookmark.BookmarkService;
 import com.devtraces.arterest.service.feed.FeedDeleteService;
 import com.devtraces.arterest.service.feed.FeedReadService;
@@ -10,12 +20,17 @@ import com.devtraces.arterest.service.like.LikeService;
 import com.devtraces.arterest.service.reply.ReplyService;
 import com.devtraces.arterest.service.rereply.RereplyService;
 import com.devtraces.arterest.service.s3.S3Service;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class FeedDeleteApplicationTest {
@@ -43,22 +58,62 @@ class FeedDeleteApplicationTest {
     @DisplayName("게시물 1개 삭제 성공")
     void successDeleteFeed(){
         // given
+        User user = User.builder()
+            .id(1L)
+            .build();
+
+        Feed deleteTargetFeed = Feed.builder()
+            .id(1L)
+            .user(user)
+            .imageUrls("imageUrl1")
+            .build();
+
+        given(feedReadService.getOneFeedEntity(1L)).willReturn(deleteTargetFeed);
+        doNothing().when(s3Service).deleteImage(anyString());
+        doNothing().when(hashtagService).deleteHashtagRelatedData(any());
+        doNothing().when(likeService).deleteLikeRelatedData(1L);
+        doNothing().when(bookmarkService).deleteAllFeedRelatedBookmark(1L);
+        doNothing().when(rereplyService).deleteAllFeedRelatedRereply(any());
+        doNothing().when(replyService).deleteAllFeedRelatedReply(any());
+        doNothing().when(feedDeleteService).deleteFeedEntity(1L);
 
         // when
+        feedDeleteApplication.deleteFeed(1L, 1L);
 
         // then
-
+        verify(feedReadService, times(1)).getOneFeedEntity(1L);
+        verify(s3Service, times(1)).deleteImage(anyString());
+        verify(hashtagService, times(1)).deleteHashtagRelatedData(any());
+        verify(likeService, times(1)).deleteLikeRelatedData(1L);
+        verify(bookmarkService, times(1)).deleteAllFeedRelatedBookmark(1L);
+        verify(rereplyService, times(1)).deleteAllFeedRelatedRereply(any());
+        verify(replyService, times(1)).deleteAllFeedRelatedReply(any());
+        verify(feedDeleteService, times(1)).deleteFeedEntity(1L);
     }
 
     @Test
     @DisplayName("게시물 1개 삭제 실패 - 유저 정보 불일치")
     void failedDeleteFeedUserInfoNotMatch(){
-        // given
+        User user = User.builder()
+            .id(1L)
+            .build();
+
+        Feed deleteTargetFeed = Feed.builder()
+            .id(1L)
+            .user(user)
+            .imageUrls("imageUrl1")
+            .build();
+
+        given(feedReadService.getOneFeedEntity(1L)).willReturn(deleteTargetFeed);
 
         // when
+        BaseException exception = assertThrows(
+            BaseException.class ,
+            () -> feedDeleteApplication.deleteFeed(2L, 1L)
+        );
 
         // then
-
+        assertEquals(ErrorCode.USER_INFO_NOT_MATCH, exception.getErrorCode());
     }
 
 }

--- a/src/test/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplicationTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplicationTest.java
@@ -1,0 +1,64 @@
+package com.devtraces.arterest.service.feed.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.devtraces.arterest.service.bookmark.BookmarkService;
+import com.devtraces.arterest.service.feed.FeedDeleteService;
+import com.devtraces.arterest.service.feed.FeedReadService;
+import com.devtraces.arterest.service.hashtag.HashtagService;
+import com.devtraces.arterest.service.like.LikeService;
+import com.devtraces.arterest.service.reply.ReplyService;
+import com.devtraces.arterest.service.rereply.RereplyService;
+import com.devtraces.arterest.service.s3.S3Service;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FeedDeleteApplicationTest {
+
+    @Mock
+    private FeedDeleteService feedDeleteService;
+    @Mock
+    private FeedReadService feedReadService;
+    @Mock
+    private S3Service s3Service;
+    @Mock
+    private HashtagService hashtagService;
+    @Mock
+    private LikeService likeService;
+    @Mock
+    private BookmarkService bookmarkService;
+    @Mock
+    private RereplyService rereplyService;
+    @Mock
+    private ReplyService replyService;
+    @InjectMocks
+    private FeedDeleteApplication feedDeleteApplication;
+
+    @Test
+    @DisplayName("게시물 1개 삭제 성공")
+    void successDeleteFeed(){
+        // given
+
+        // when
+
+        // then
+
+    }
+
+    @Test
+    @DisplayName("게시물 1개 삭제 실패 - 유저 정보 불일치")
+    void failedDeleteFeedUserInfoNotMatch(){
+        // given
+
+        // when
+
+        // then
+
+    }
+
+}

--- a/src/test/java/com/devtraces/arterest/service/hashtag/HashtagServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/hashtag/HashtagServiceTest.java
@@ -1,0 +1,66 @@
+package com.devtraces.arterest.service.hashtag;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMap;
+import com.devtraces.arterest.model.feedhashtagmap.FeedHashtagMapRepository;
+import com.devtraces.arterest.model.hashtag.Hashtag;
+import com.devtraces.arterest.model.hashtag.HashtagRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @Mock
+    private HashtagRepository hashtagRepository;
+    @Mock
+    private FeedHashtagMapRepository feedHashtagMapRepository;
+    @InjectMocks
+    private HashtagService hashtagService;
+
+    @Test
+    @DisplayName("해시태그 관련 정부 삭제 완료")
+    void successDeleteHashtagRelatedData(){
+        // given
+        Feed feed = Feed.builder()
+            .id(1L)
+            .build();
+
+        Hashtag hashtag = Hashtag.builder()
+            .id(1L)
+            .build();
+
+        FeedHashtagMap feedHashtagMapEntity = FeedHashtagMap.builder()
+            .id(1L)
+            .hashtag(hashtag)
+            .feed(feed)
+            .build();
+
+        List<FeedHashtagMap> feedHashtagMapList = new ArrayList<>();
+        feedHashtagMapList.add(feedHashtagMapEntity);
+
+        given(feedHashtagMapRepository.findByFeed(feed)).willReturn(feedHashtagMapList);
+        doNothing().when(feedHashtagMapRepository).deleteAllByFeedId(1L);
+
+        // when
+        hashtagService.deleteHashtagRelatedData(feed);
+
+        // then
+        verify(feedHashtagMapRepository, times(1)).findByFeed(any());
+        verify(feedHashtagMapRepository, times(1)).deleteAllByFeedId(1L);
+    }
+
+}

--- a/src/test/java/com/devtraces/arterest/service/like/LikeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/like/LikeServiceTest.java
@@ -217,4 +217,19 @@ class LikeServiceTest {
         assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
     }
 
+    @Test
+    @DisplayName("게시물 삭제시 좋아요 관련 정보 삭제 성공")
+    void successDeleteFeedRelatedLikeData(){
+        // given
+        doNothing().when(likeNumberCacheRepository).deleteLikeNumberInfo(1L);
+        doNothing().when(likeRepository).deleteAllByFeedId(1L);
+
+        // when
+        likeService.deleteLikeRelatedData(1L);
+
+        // then
+        verify(likeNumberCacheRepository, times(1)).deleteLikeNumberInfo(1L);
+        verify(likeRepository).deleteAllByFeedId(1L);
+    }
+
 }

--- a/src/test/java/com/devtraces/arterest/service/reply/ReplyServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/reply/ReplyServiceTest.java
@@ -373,4 +373,29 @@ class ReplyServiceTest {
         assertEquals(ErrorCode.USER_INFO_NOT_MATCH, exception.getErrorCode());
     }
 
+    @Test
+    @DisplayName("피드 관련 댓글들 삭제 성공")
+    void successDeleteAllFeedRelatedReply(){
+        // given
+        Reply reply = Reply.builder()
+            .id(1L)
+            .rereplyList(new ArrayList<>())
+            .build();
+
+        Feed feed = Feed.builder()
+            .id(1L)
+            .replyList(new ArrayList<>())
+            .build();
+
+        feed.getReplyList().add(reply);
+
+        doNothing().when(replyRepository).deleteAllByIdIn(anyList());
+
+        // when
+        replyService.deleteAllFeedRelatedReply(feed);
+
+        // then
+        verify(replyRepository, times(1)).deleteAllByIdIn(anyList());
+    }
+
 }

--- a/src/test/java/com/devtraces/arterest/service/rereply/RereplyServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/rereply/RereplyServiceTest.java
@@ -2,6 +2,7 @@ package com.devtraces.arterest.service.rereply;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.verify;
 
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.exception.ErrorCode;
+import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.reply.Reply;
 import com.devtraces.arterest.model.reply.ReplyRepository;
 import com.devtraces.arterest.model.rereply.Rereply;
@@ -346,6 +348,37 @@ class RereplyServiceTest {
 
         // then
         assertEquals(ErrorCode.USER_INFO_NOT_MATCH, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("피드 관련 대댓글들 삭제 성공")
+    void successDeleteAllFeedRelatedRereply(){
+        // given
+        Rereply rereply = Rereply.builder()
+            .id(1L)
+            .build();
+
+        Reply reply = Reply.builder()
+            .id(1L)
+            .rereplyList(new ArrayList<>())
+            .build();
+
+        reply.getRereplyList().add(rereply);
+
+        Feed feed = Feed.builder()
+            .id(1L)
+            .replyList(new ArrayList<>())
+            .build();
+
+        feed.getReplyList().add(reply);
+
+        doNothing().when(rereplyRepository).deleteAllByIdIn(anyList());
+
+        // when
+        rereplyService.deleteAllFeedRelatedRereply(feed);
+
+        // then
+        verify(rereplyRepository, times(1)).deleteAllByIdIn(anyList());
     }
 
 }


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #104 

## 📍 특이사항
- 기존 게시물 삭제 메서드가 지나치게 많은 리포지토리들을 참조하면서 다양한 로직을 하나의 메서드에서 전부 처리하고 있던 것을 리팩토링함.
- FeedDeleteApplication도 결국은 서비스이기 때문에 서비스가 다른 서비스를 호출하는 상황에서 중간에 뭔가 잘못됐을 때 롤백이 잘 되는지를 로컬 환경에서 테스트를 완료하고 Application 계층을 추가하는 구조를 선택했음
- [로컬 환경에서 미니 프로젝트로 테스트 해본 결과, Transactional 어노테이션에서 Propagation을 default인 Required로 설정한 경우, Application이 호출하는 하위 서비스에서 예외가 발생했을 때 Application 동작 전체가 잘 롤백되는 것을 확인했음](https://github.com/DongvinPark/jpa-propagation-test).
- 게시물 1개 삭제를 위해서 필요한 여러 개의 부분 기능들을 해당하는 각각의 서비스 클래스들 안으로 옮긴 후, FeedDeleteApplication이 각각의 서비스들을 순차적으로 호출하면서 로직을 처리하게 함.
- FeedDeleteApplication은 8개의 서비스를 호출하지만, 이렇게 호출되는 각각의 서비스들은 자신과 관련없는 리포지토리를 과도하게 많이 참조하지 않고 오직 자기 영역의 할일만 할 수 있도록 구조를 변경함.
- 리팩토링에 따른 테스트코드 수정도 완료함.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트