### PR TITLE
4가지 알림 저장 기능 구현 

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/type/NoticeTarget.java
+++ b/src/main/java/com/devtraces/arterest/common/type/NoticeTarget.java
@@ -1,0 +1,5 @@
+package com.devtraces.arterest.common.type;
+
+public enum NoticeTarget {
+    POST, REPLY
+}

--- a/src/main/java/com/devtraces/arterest/common/type/NoticeType.java
+++ b/src/main/java/com/devtraces/arterest/common/type/NoticeType.java
@@ -1,0 +1,5 @@
+package com.devtraces.arterest.common.type;
+
+public enum NoticeType {
+    LIKE, FOLLOW, REPLY, REREPLY
+}

--- a/src/main/java/com/devtraces/arterest/model/notice/Notice.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/Notice.java
@@ -29,7 +29,7 @@ public class Notice extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
-    private User sendUser; // 알림을 발생시킨 유저
+    private User user; // 알림을 발생시킨 유저
 
     @ManyToOne
     @JoinColumn(name = "feed_id")

--- a/src/main/java/com/devtraces/arterest/model/notice/Notice.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/Notice.java
@@ -1,0 +1,51 @@
+package com.devtraces.arterest.model.notice;
+
+import com.devtraces.arterest.common.model.BaseEntity;
+import com.devtraces.arterest.common.type.NoticeTarget;
+import com.devtraces.arterest.common.type.NoticeType;
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.reply.Reply;
+import com.devtraces.arterest.model.rereply.Rereply;
+import com.devtraces.arterest.model.user.User;
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@AuditOverride(forClass = BaseEntity.class)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Notice extends BaseEntity {
+
+    @Id
+    @Column(name = "notice_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long noticeOwnerId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User sendUser; // 알림을 발생시킨 유저
+
+    @ManyToOne
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+
+    @ManyToOne
+    @JoinColumn(name = "reply_id")
+    private Reply reply;
+
+    @ManyToOne
+    @JoinColumn(name = "rereply_id")
+    private Rereply rereply;
+
+    @Enumerated(EnumType.STRING)
+    private NoticeType noticeType;
+
+    @Enumerated(EnumType.STRING)
+    private NoticeTarget noticeTarget;
+}

--- a/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
@@ -1,0 +1,6 @@
+package com.devtraces.arterest.model.notice;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -1,0 +1,146 @@
+package com.devtraces.arterest.service.notice;
+
+import com.devtraces.arterest.common.exception.BaseException;
+import com.devtraces.arterest.common.type.NoticeTarget;
+import com.devtraces.arterest.common.type.NoticeType;
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.model.notice.Notice;
+import com.devtraces.arterest.model.notice.NoticeRepository;
+import com.devtraces.arterest.model.reply.Reply;
+import com.devtraces.arterest.model.reply.ReplyRepository;
+import com.devtraces.arterest.model.rereply.Rereply;
+import com.devtraces.arterest.model.rereply.RereplyRepository;
+import com.devtraces.arterest.model.user.User;
+import com.devtraces.arterest.model.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final UserRepository userRepository;
+    private final FeedRepository feedRepository;
+    private final ReplyRepository replyRepository;
+    private final RereplyRepository rereplyRepository;
+
+    public void createLikeNotice(
+            Long sendUserId, Long feedId
+    ) {
+        Feed feed = getFeed(feedId);
+
+        noticeRepository.save(
+                Notice.builder()
+                        .noticeOwnerId(feed.getUser().getId()) // 좋아요 누른 피드의 주인
+                        .sendUser(getUser(sendUserId)) // 좋아요 누른 사용자
+                        .feed(feed)
+                        .noticeType(NoticeType.LIKE)
+                        .build()
+        );
+    }
+
+    public void createFollowNotice(String nickname, Long sendUserId) {
+        User ownerUser = userRepository.findByNickname(nickname).orElseThrow(
+                () -> BaseException.USER_NOT_FOUND
+        );
+
+        noticeRepository.save(
+                Notice.builder()
+                        .noticeOwnerId(ownerUser.getId()) // 팔로우 당한 사람
+                        .sendUser(getUser(sendUserId)) // 팔로우 한 사람
+                        .noticeType(NoticeType.FOLLOW)
+                        .build()
+        );
+    }
+
+    public void createReplyNotice(
+            Long sendUserId, Long feedId, Long replyId
+    ) {
+        Feed feed = getFeed(feedId);
+
+        noticeRepository.save(
+                Notice.builder()
+                        .noticeOwnerId(feed.getUser().getId()) // 댓글 단 피드의 주인
+                        .sendUser(getUser(sendUserId)) // 댓글 단 사람
+                        .feed(feed)
+                        .reply(getReply(replyId))
+                        .noticeType(NoticeType.REPLY)
+                        .build()
+        );
+    }
+
+    public void createReReplyNotice(
+            Long sendUserId, Long feedId,
+            Long replyId, Long reReplyId
+    ) {
+        Feed feed = getFeed(feedId);
+        Reply reply = getReply(replyId);
+        User sendUser = getUser(sendUserId);
+        Rereply reReply = getReReply(reReplyId);
+
+        // feed 주인에게 알림 저장
+        noticeRepository.save(
+                buildReReplyNotice(
+                        feed.getUser().getId(), // 대댓글 달린 피드 주인
+                        sendUser, // 대댓글 단 사람
+                        feed,
+                        reply,
+                        reReply,
+                        NoticeType.REREPLY,
+                        NoticeTarget.POST // 피드 주인을 대상으로 함
+                )
+        );
+
+        // 댓글 주인에게 알림 저장
+        noticeRepository.save(
+                buildReReplyNotice(
+                        reply.getUser().getId(), // 대댓글 달린 댓글 주인
+                        sendUser, // 대댓글 단 사람
+                        feed,
+                        reply,
+                        reReply,
+                        NoticeType.REREPLY,
+                        NoticeTarget.REPLY // 댓글 주인을 대상으로 함
+                )
+        );
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> BaseException.USER_NOT_FOUND);
+    }
+
+    private Feed getFeed(Long feedId) {
+        return feedRepository.findById(feedId).orElseThrow(
+                () -> BaseException.FEED_NOT_FOUND);
+    }
+
+    private Reply getReply(Long replyId) {
+        return replyRepository.findById(replyId).orElseThrow(
+                () -> BaseException.REPLY_NOT_FOUND
+        );
+    }
+
+    private Rereply getReReply(Long reReplyId) {
+        return rereplyRepository.findById(reReplyId).orElseThrow(
+                () -> BaseException.REREPLY_NOT_FOUND
+        );
+    }
+
+    private Notice buildReReplyNotice(
+            Long ownerUserId, User sendUser, Feed feed, Reply reply,
+            Rereply reReply, NoticeType noticeType, NoticeTarget noticeTarget
+    ) {
+        return Notice.builder()
+                .noticeOwnerId(ownerUserId)
+                .sendUser(sendUser)
+                .feed(feed)
+                .reply(reply)
+                .rereply(reReply)
+                .noticeType(noticeType)
+                .noticeTarget(noticeTarget)
+                .build();
+    }
+}

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -34,7 +34,7 @@ public class NoticeService {
         noticeRepository.save(
                 Notice.builder()
                         .noticeOwnerId(feed.getUser().getId()) // 좋아요 누른 피드의 주인
-                        .sendUser(getUser(sendUserId)) // 좋아요 누른 사용자
+                        .user(getUser(sendUserId)) // 좋아요 누른 사용자
                         .feed(feed)
                         .noticeType(NoticeType.LIKE)
                         .build()
@@ -49,7 +49,7 @@ public class NoticeService {
         noticeRepository.save(
                 Notice.builder()
                         .noticeOwnerId(ownerUser.getId()) // 팔로우 당한 사람
-                        .sendUser(getUser(sendUserId)) // 팔로우 한 사람
+                        .user(getUser(sendUserId)) // 팔로우 한 사람
                         .noticeType(NoticeType.FOLLOW)
                         .build()
         );
@@ -63,7 +63,7 @@ public class NoticeService {
         noticeRepository.save(
                 Notice.builder()
                         .noticeOwnerId(feed.getUser().getId()) // 댓글 단 피드의 주인
-                        .sendUser(getUser(sendUserId)) // 댓글 단 사람
+                        .user(getUser(sendUserId)) // 댓글 단 사람
                         .feed(feed)
                         .reply(getReply(replyId))
                         .noticeType(NoticeType.REPLY)
@@ -147,7 +147,7 @@ public class NoticeService {
     ) {
         return Notice.builder()
                 .noticeOwnerId(ownerUserId)
-                .sendUser(sendUser)
+                .user(sendUser)
                 .feed(feed)
                 .reply(reply)
                 .rereply(reReply)

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -75,12 +75,21 @@ public class NoticeService {
             Long sendUserId, Long feedId,
             Long replyId, Long reReplyId
     ) {
+        User sendUser = getUser(sendUserId);
         Feed feed = getFeed(feedId);
         Reply reply = getReply(replyId);
-        User sendUser = getUser(sendUserId);
         Rereply reReply = getReReply(reReplyId);
 
         // feed 주인에게 알림 저장
+        saveNoticeForFeedOwner(sendUser, feed, reply, reReply);
+
+        // 댓글 주인에게 알림 저장
+        saveNoticeForReplyOwner(sendUser, feed, reply, reReply);
+    }
+
+    public void saveNoticeForFeedOwner(
+            User sendUser, Feed feed, Reply reply, Rereply reReply
+    ) {
         noticeRepository.save(
                 buildReReplyNotice(
                         feed.getUser().getId(), // 대댓글 달린 피드 주인
@@ -92,8 +101,11 @@ public class NoticeService {
                         NoticeTarget.POST // 피드 주인을 대상으로 함
                 )
         );
+    }
 
-        // 댓글 주인에게 알림 저장
+    public void saveNoticeForReplyOwner(
+            User sendUser, Feed feed, Reply reply, Rereply reReply
+    ) {
         noticeRepository.save(
                 buildReReplyNotice(
                         reply.getUser().getId(), // 대댓글 달린 댓글 주인

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -1,0 +1,528 @@
+package com.devtraces.arterest.service.notice;
+
+import com.devtraces.arterest.common.exception.BaseException;
+import com.devtraces.arterest.common.exception.ErrorCode;
+import com.devtraces.arterest.common.type.NoticeTarget;
+import com.devtraces.arterest.common.type.NoticeType;
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.model.notice.Notice;
+import com.devtraces.arterest.model.notice.NoticeRepository;
+import com.devtraces.arterest.model.reply.Reply;
+import com.devtraces.arterest.model.reply.ReplyRepository;
+import com.devtraces.arterest.model.rereply.Rereply;
+import com.devtraces.arterest.model.rereply.RereplyRepository;
+import com.devtraces.arterest.model.user.User;
+import com.devtraces.arterest.model.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.devtraces.arterest.common.type.NoticeTarget.*;
+import static com.devtraces.arterest.common.type.NoticeType.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeServiceTest {
+
+    @Mock
+    private NoticeRepository noticeRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private FeedRepository feedRepository;
+    @Mock
+    private ReplyRepository replyRepository;
+    @Mock
+    private RereplyRepository rereplyRepository;
+    @InjectMocks
+    private NoticeService noticeService;
+
+    @Test
+    void success_createLikeNotice() {
+        //given
+        Long noticeOwnerId = 1L;
+        NoticeType noticeType = LIKE;
+
+        Long sendUserId = 342L;
+        User user = User.builder().id(sendUserId).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+
+        Long feedId = 9709L;
+        User ownerUser = User.builder().id(noticeOwnerId).build();
+        Feed feed = Feed.builder().id(feedId).user(ownerUser).build();
+        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
+
+        Notice notice = Notice.builder()
+                .noticeOwnerId(feed.getUser().getId())
+                .sendUser(user)
+                .feed(feed)
+                .noticeType(noticeType)
+                .build();
+        given(noticeRepository.save(any())).willReturn(notice);
+
+        ArgumentCaptor<Notice> captor = ArgumentCaptor.forClass(Notice.class);
+
+        //when
+        noticeService.createLikeNotice(sendUserId, feedId);
+
+        //then
+        verify(noticeRepository, times(1)).save(captor.capture());
+        assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
+        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(feedId, captor.getValue().getFeed().getId());
+        assertEquals(LIKE, captor.getValue().getNoticeType());
+    }
+
+    @Test
+    void success_createFollowNotice() {
+        //given
+        NoticeType noticeType = FOLLOW;
+
+        Long sendUserId = 342L;
+        User user = User.builder().id(sendUserId).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+
+        Long noticeOwnerId = 1L;
+        String nickname = "ownerNickname";
+        User ownerUser = User.builder().id(noticeOwnerId).nickname(nickname).build();
+        given(userRepository.findByNickname(anyString())).willReturn(Optional.of(ownerUser));
+
+        Notice notice = Notice.builder()
+                .noticeOwnerId(ownerUser.getId())
+                .sendUser(user)
+                .noticeType(noticeType)
+                .build();
+        given(noticeRepository.save(any())).willReturn(notice);
+
+        ArgumentCaptor<Notice> captor = ArgumentCaptor.forClass(Notice.class);
+
+        //when
+        noticeService.createFollowNotice(nickname, sendUserId);
+
+        //then
+        verify(noticeRepository, times(1)).save(captor.capture());
+        assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
+        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(FOLLOW, captor.getValue().getNoticeType());
+    }
+
+    @Test
+    void success_createReplyNotice() {
+        //given
+        Long noticeOwnerId = 1L;
+        User ownerUser = User.builder().id(noticeOwnerId).build();
+
+        Long sendUserId = 342L;
+        User user = User.builder().id(sendUserId).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+
+        Long feedId = 9709L;
+        Feed feed = Feed.builder().id(feedId).user(ownerUser).build();
+        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
+
+        Long replyId = 103L;
+        Reply reply = Reply.builder().id(replyId).build();
+        given(replyRepository.findById(anyLong())).willReturn(Optional.of(reply));
+
+        NoticeType noticeType = NoticeType.REPLY;
+
+        Notice notice = Notice.builder()
+                .noticeOwnerId(feed.getUser().getId())
+                .sendUser(user)
+                .feed(feed)
+                .noticeType(noticeType)
+                .build();
+        given(noticeRepository.save(any())).willReturn(notice);
+
+        ArgumentCaptor<Notice> captor = ArgumentCaptor.forClass(Notice.class);
+
+        //when
+        noticeService.createReplyNotice(sendUserId, feedId, replyId);
+
+        //then
+        verify(noticeRepository, times(1)).save(captor.capture());
+        assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
+        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(feedId, captor.getValue().getFeed().getId());
+        assertEquals(replyId, captor.getValue().getReply().getId());
+        assertEquals(NoticeType.REPLY, captor.getValue().getNoticeType());
+    }
+
+    @Test
+    void success_saveNoticeForFeedOwner() {
+        //given
+        Long feedOwnerId = 1L;
+        User feedOwnerUser = User.builder().id(feedOwnerId).build();
+
+        Long replyOwnerId = 2L;
+        User replyOwnerUser = User.builder().id(replyOwnerId).build();
+
+        Long sendUserId = 342L;
+        User sendUser = User.builder().id(sendUserId).build();
+
+        Long feedId = 9709L;
+        Feed feed = Feed.builder().id(feedId).user(feedOwnerUser).build();
+
+        Long replyId = 103L;
+        Reply reply = Reply.builder().id(replyId).user(replyOwnerUser).build();
+
+        Long reReplyId = 1231L;
+        Rereply reReply = Rereply.builder().id(reReplyId).reply(reply).build();
+
+        NoticeType noticeType = REREPLY;
+
+        Notice noticeForFeedOwner = Notice.builder()
+                .noticeOwnerId(feed.getUser().getId())
+                .sendUser(sendUser)
+                .feed(feed)
+                .reply(reply)
+                .rereply(reReply)
+                .noticeType(noticeType)
+                .noticeTarget(POST)
+                .build();
+
+        given(noticeRepository.save(any())).willReturn(noticeForFeedOwner);
+
+        ArgumentCaptor<Notice> captor = ArgumentCaptor.forClass(Notice.class);
+
+        //when
+        noticeService.saveNoticeForFeedOwner(sendUser, feed, reply, reReply);
+
+        //then
+        verify(noticeRepository, times(1)).save(captor.capture());
+        assertEquals(feedOwnerId, captor.getValue().getNoticeOwnerId());
+        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(feedId, captor.getValue().getFeed().getId());
+        assertEquals(replyId, captor.getValue().getReply().getId());
+        assertEquals(POST, captor.getValue().getNoticeTarget());
+        assertEquals(REREPLY, captor.getValue().getNoticeType());
+    }
+
+    @Test
+    void success_saveNoticeForReplyOwner() {
+        //given
+        Long feedOwnerId = 1L;
+        User feedOwnerUser = User.builder().id(feedOwnerId).build();
+
+        Long replyOwnerId = 2L;
+        User replyOwnerUser = User.builder().id(replyOwnerId).build();
+
+        Long sendUserId = 342L;
+        User sendUser = User.builder().id(sendUserId).build();
+
+        Long feedId = 9709L;
+        Feed feed = Feed.builder().id(feedId).user(feedOwnerUser).build();
+
+        Long replyId = 103L;
+        Reply reply = Reply.builder().id(replyId).user(replyOwnerUser).build();
+
+        Long reReplyId = 1231L;
+        Rereply reReply = Rereply.builder().id(reReplyId).reply(reply).build();
+
+        NoticeType noticeType = REREPLY;
+
+        Notice noticeForReplyOwner = Notice.builder()
+                .noticeOwnerId(reply.getUser().getId())
+                .sendUser(sendUser)
+                .feed(feed)
+                .reply(reply)
+                .rereply(reReply)
+                .noticeType(noticeType)
+                .noticeTarget(NoticeTarget.REPLY)
+                .build();
+
+        given(noticeRepository.save(any())).willReturn(noticeForReplyOwner);
+
+        ArgumentCaptor<Notice> captor = ArgumentCaptor.forClass(Notice.class);
+
+        //when
+        noticeService.saveNoticeForReplyOwner(sendUser, feed, reply, reReply);
+
+        //then
+        verify(noticeRepository, times(1)).save(captor.capture());
+        assertEquals(replyOwnerId, captor.getValue().getNoticeOwnerId());
+        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(feedId, captor.getValue().getFeed().getId());
+        assertEquals(replyId, captor.getValue().getReply().getId());
+        assertEquals(NoticeTarget.REPLY, captor.getValue().getNoticeTarget());
+        assertEquals(REREPLY, captor.getValue().getNoticeType());
+    }
+
+    @Test
+    @DisplayName("좋아요 알림 생성 실패 - 존재하지 않는 사용자")
+    void fail_createLikeNotice_USER_NOT_FOUND() {
+        //given
+        Long sendUserId = 1L;
+        Long feedId = 2L;
+
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //when
+        BaseException exception =
+                assertThrows(
+                        BaseException.class,
+                        () -> noticeService.createLikeNotice(sendUserId, feedId)
+                );
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("좋아요 알림 생성 실패 - 존재하지 않는 피드")
+    void fail_createLikeNotice_FEED_NOT_FOUND() {
+        //given
+        Long sendUserId = 1L;
+
+        Long feedId = 2L;
+        given(feedRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //when
+        BaseException exception =
+                assertThrows(
+                        BaseException.class,
+                        () -> noticeService.createLikeNotice(sendUserId, feedId)
+                );
+
+        //then
+        assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("팔로우 알림 생성 실패 - 알림 대상 사용자가 존재하지 않음")
+    void fail_createFollowNotice_OWNER_USER_NOT_FOUND() {
+        //given
+        String nickname = "nickname";
+        Long sendUserId = 2L;
+
+        given(userRepository.findByNickname(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+        BaseException exception =
+                assertThrows(
+                        BaseException.class,
+                        () -> noticeService.createFollowNotice(nickname, sendUserId)
+                );
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("팔로우 알림 생성 실패 - 알림 보내는 사용자가 존재하지 않음")
+    void fail_createFollowNotice_SEND_USER_NOT_FOUND() {
+        //given
+        String nickname = "nickname";
+        User ownerUser = User.builder().nickname(nickname).build();
+        given(userRepository.findByNickname(anyString()))
+                .willReturn(Optional.of(ownerUser));
+
+        Long sendUserId = 342L;
+
+        //when
+        BaseException exception =
+                assertThrows(
+                        BaseException.class,
+                        () -> noticeService.createFollowNotice(nickname, sendUserId)
+                );
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("댓글 알림 생성 실패 - 존재하지 않는 피드")
+    void fail_createReplyNotice_FEED_NOT_FOUND() {
+        //given
+        Long sendUserId = 342L;
+        Long feedId = 9709L;
+        Long replyId = 103L;
+
+        given(feedRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //when
+        BaseException exception = assertThrows(
+                BaseException.class,
+                () -> noticeService.createReplyNotice(sendUserId, feedId, replyId)
+        );
+
+        //then
+        assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("댓글 알림 생성 실패 - 존재하지 않는 댓글 작성자")
+    void fail_createReplyNotice_SEND_USER_NOT_FOUND() {
+        //given
+        Long noticeOwnerId = 1L;
+        User ownerUser = User.builder().id(noticeOwnerId).build();
+
+        Long sendUserId = 342L;
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        Long feedId = 9709L;
+        Feed feed = Feed.builder().id(feedId).user(ownerUser).build();
+        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
+
+        Long replyId = 103L;
+
+        //when
+        BaseException exception = assertThrows(
+                BaseException.class,
+                () -> noticeService.createReplyNotice(sendUserId, feedId, replyId)
+        );
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("댓글 알림 생성 실패 - 존재하지 않는 댓글")
+    void fail_createReplyNotice_REPLY_NOT_FOUND() {
+        //given
+        Long noticeOwnerId = 1L;
+        User ownerUser = User.builder().id(noticeOwnerId).build();
+
+        Long sendUserId = 342L;
+        User user = User.builder().id(sendUserId).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+
+        Long feedId = 9709L;
+        Feed feed = Feed.builder().id(feedId).user(ownerUser).build();
+        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
+
+        Long replyId = 103L;
+        given(replyRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //when
+        BaseException exception = assertThrows(
+                BaseException.class,
+                () -> noticeService.createReplyNotice(sendUserId, feedId, replyId)
+        );
+
+        //then
+        assertEquals(ErrorCode.REPLY_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("댓글 알림 생성 실패 - 존재하지 않는 사용자")
+    void fail_createReReplyNotice_USER_NOT_FOUND() {
+        //given
+        Long sendUserId = 1L;
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        Long feedId = 2L;
+        Long replyId = 3L;
+        Long reReplyId = 4L;
+
+        //when
+        BaseException exception = assertThrows(
+                BaseException.class,
+                () -> noticeService.createReReplyNotice(sendUserId, feedId, replyId, reReplyId)
+        );
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("대댓글 알림 생성 실패 - 존재하지 않는 피드")
+    void fail_createReReplyNotice_FEED_NOT_FOUND() {
+        //given
+        Long sendUserId = 1L;
+        User sendUser = User.builder().id(sendUserId).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(sendUser));
+
+        Long feedId = 2L;
+        given(feedRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        Long replyId = 3L;
+        Long reReplyId = 4L;
+
+        //when
+        BaseException exception = assertThrows(
+                BaseException.class,
+                () -> noticeService.createReReplyNotice(sendUserId, feedId, replyId, reReplyId)
+        );
+
+        //then
+        assertEquals(ErrorCode.FEED_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("대댓글 알림 생성 실패 - 존재하지 않는 댓글")
+    void fail_createReReplyNotice_REPLY_NOT_FOUND() {
+        //given
+        Long sendUserId = 1L;
+        User sendUser = User.builder().id(sendUserId).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(sendUser));
+
+        Long feedOwnerId = 1L;
+        User feedOwnerUser = User.builder().id(feedOwnerId).build();
+
+        Long feedId = 2L;
+        Feed feed = Feed.builder().id(feedId).user(feedOwnerUser).build();
+        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
+
+        Long replyId = 3L;
+        given(replyRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        Long reReplyId = 4L;
+
+        //when
+        BaseException exception = assertThrows(
+                BaseException.class,
+                () -> noticeService.createReReplyNotice(sendUserId, feedId, replyId, reReplyId)
+        );
+
+        //then
+        assertEquals(ErrorCode.REPLY_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("대댓글 알림 생성 실패 - 존재하지 않는 대댓글")
+    void fail_createReReplyNotice_REREPLY_NOT_FOUND() {
+        //given
+        Long sendUserId = 74L;
+        User sendUser = User.builder().id(sendUserId).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(sendUser));
+
+        Long feedOwnerId = 2342L;
+        User feedOwnerUser = User.builder().id(feedOwnerId).build();
+
+        Long feedId = 642L;
+        Feed feed = Feed.builder().id(feedId).user(feedOwnerUser).build();
+        given(feedRepository.findById(anyLong())).willReturn(Optional.of(feed));
+
+        Long replyOwnerId = 3151L;
+        User replyOwnerUser = User.builder().id(replyOwnerId).build();
+
+        Long replyId = 351L;
+        Reply reply = Reply.builder().id(replyId).user(replyOwnerUser).build();
+        given(replyRepository.findById(anyLong())).willReturn(Optional.of(reply));
+
+        Long reReplyId = 135L;
+        given(rereplyRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //when
+        BaseException exception = assertThrows(
+                BaseException.class,
+                () -> noticeService.createReReplyNotice(sendUserId, feedId, replyId, reReplyId)
+        );
+
+        //then
+        assertEquals(ErrorCode.REREPLY_NOT_FOUND, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #103 

## 📍 특이사항
* 좋아요, 팔로우, 댓글, 대댓글 알림 저장기능을 구현했습니다. 
* 구체적인 내용을 저장하는 것이 아닌 연관 객체(user, feed, reply, rereply) id만 저장하는 로직으로 진행했습니다.
* 구체적인 정보는 알림 조회 리스트에서 구현할 예정입니다. 
* rereply의 경우 댓글 작성자와 댓글이 있는 피드의 작성자 모두에게 알림이 가서 이를 구분하기 위해 NoticeTarget이라는 enum 클래스를 이용했습니다. 
    * NoticeType.POST, NoticeType.REPLY 형식입니다. 

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
