### PR TITLE
알림 개수/리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/notice/NoticeController.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/NoticeController.java
@@ -1,6 +1,7 @@
 package com.devtraces.arterest.controller.notice;
 
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
+import com.devtraces.arterest.controller.notice.dto.response.NoticeListResponse;
 import com.devtraces.arterest.controller.notice.dto.NumberOfNoticeResponse;
 import com.devtraces.arterest.service.notice.NoticeService;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,5 +24,12 @@ public class NoticeController {
             @AuthenticationPrincipal Long userId
     ) {
         return ApiSuccessResponse.from(noticeService.getNumberOfNotice(userId));
+    }
+
+    @GetMapping()
+    public ApiSuccessResponse<List<NoticeListResponse>> getNoticeList(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiSuccessResponse.from(noticeService.getNoticeList(userId));
     }
 }

--- a/src/main/java/com/devtraces/arterest/controller/notice/NoticeController.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/NoticeController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -28,8 +29,11 @@ public class NoticeController {
 
     @GetMapping()
     public ApiSuccessResponse<List<NoticeListResponse>> getNoticeList(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal Long userId,
+            @RequestParam int page,
+            @RequestParam(required = false, defaultValue = "10") int pageSize
     ) {
-        return ApiSuccessResponse.from(noticeService.getNoticeList(userId));
+        return ApiSuccessResponse.from(
+                noticeService.getNoticeList(userId, page, pageSize));
     }
 }

--- a/src/main/java/com/devtraces/arterest/controller/notice/NoticeController.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/NoticeController.java
@@ -1,0 +1,25 @@
+package com.devtraces.arterest.controller.notice;
+
+import com.devtraces.arterest.common.response.ApiSuccessResponse;
+import com.devtraces.arterest.controller.notice.dto.NumberOfNoticeResponse;
+import com.devtraces.arterest.service.notice.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping("/counts")
+    public ApiSuccessResponse<NumberOfNoticeResponse> getNumberOfNotices(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiSuccessResponse.from(noticeService.getNumberOfNotices(userId));
+    }
+}

--- a/src/main/java/com/devtraces/arterest/controller/notice/NoticeController.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/NoticeController.java
@@ -20,6 +20,6 @@ public class NoticeController {
     public ApiSuccessResponse<NumberOfNoticeResponse> getNumberOfNotices(
             @AuthenticationPrincipal Long userId
     ) {
-        return ApiSuccessResponse.from(noticeService.getNumberOfNotices(userId));
+        return ApiSuccessResponse.from(noticeService.getNumberOfNotice(userId));
     }
 }

--- a/src/main/java/com/devtraces/arterest/controller/notice/dto/FollowNoticeDto.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/dto/FollowNoticeDto.java
@@ -1,5 +1,6 @@
-package com.devtraces.arterest.controller.notice.dto.response;
+package com.devtraces.arterest.controller.notice.dto;
 
+import com.devtraces.arterest.controller.notice.dto.response.NoticeListResponse;
 import com.devtraces.arterest.model.notice.Notice;
 import com.devtraces.arterest.model.user.User;
 import lombok.*;
@@ -20,7 +21,7 @@ public class FollowNoticeDto extends NoticeListResponse {
 
     private String createdAt;
 
-    public static FollowNoticeDto followNotice(Notice notice, boolean isFollowing) {
+    public static FollowNoticeDto convertToFollowNotice(Notice notice, boolean isFollowing) {
         User user = notice.getUser();
 
         return FollowNoticeDto.builder()

--- a/src/main/java/com/devtraces/arterest/controller/notice/dto/FollowNoticeDto.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/dto/FollowNoticeDto.java
@@ -1,0 +1,35 @@
+package com.devtraces.arterest.controller.notice.dto.response;
+
+import com.devtraces.arterest.model.notice.Notice;
+import com.devtraces.arterest.model.user.User;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FollowNoticeDto extends NoticeListResponse {
+
+    private Long noticeId;
+    private String noticeType;
+    private String senderNickname;
+    private String senderProfileImageUrl;
+
+    // isFollowing으로 하면 following으로 출력되기 때문에 is 중복 사용
+    private boolean isIsFollowing;
+
+    private String createdAt;
+
+    public static FollowNoticeDto followNotice(Notice notice, boolean isFollowing) {
+        User user = notice.getUser();
+
+        return FollowNoticeDto.builder()
+                .noticeId(notice.getId())
+                .noticeType(notice.getNoticeType().toString())
+                .senderNickname(user.getNickname())
+                .senderProfileImageUrl(user.getProfileImageUrl())
+                .isIsFollowing(isFollowing)
+                .createdAt(notice.getCreatedAt().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/devtraces/arterest/controller/notice/dto/LikeNoticeDto.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/dto/LikeNoticeDto.java
@@ -23,7 +23,7 @@ public class LikeNoticeDto extends NoticeListResponse {
 
     private String createdAt;
 
-    public static LikeNoticeDto likeNotice(Notice notice) {
+    public static LikeNoticeDto convertToLikeNotice(Notice notice) {
         Feed feed = notice.getFeed();
 
         return LikeNoticeDto.builder()

--- a/src/main/java/com/devtraces/arterest/controller/notice/dto/LikeNoticeDto.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/dto/LikeNoticeDto.java
@@ -1,0 +1,40 @@
+package com.devtraces.arterest.controller.notice.dto;
+
+
+import com.devtraces.arterest.controller.notice.dto.response.NoticeListResponse;
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.notice.Notice;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LikeNoticeDto extends NoticeListResponse {
+
+    private Long noticeId;
+    private String noticeType;
+    private String senderNickname;
+    private String senderProfileImageUrl;
+
+    private Long feedId;
+    private String feedFirstImageUrl;
+    private String feedContent;
+
+    private String createdAt;
+
+    public static LikeNoticeDto likeNotice(Notice notice) {
+        Feed feed = notice.getFeed();
+
+        return LikeNoticeDto.builder()
+                .noticeId(notice.getId())
+                .noticeType(notice.getNoticeType().toString())
+                .senderNickname(notice.getUser().getNickname())
+                .senderProfileImageUrl(notice.getUser().getProfileImageUrl())
+                .feedId(feed.getId())
+                .feedFirstImageUrl(feed.getImageUrls().split(",")[0]) // 피드 첫번째 이미지 가져오기
+                .feedContent(getShortenContent(feed.getContent()))
+                .createdAt(notice.getCreatedAt().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/devtraces/arterest/controller/notice/dto/NumberOfNoticeResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/dto/NumberOfNoticeResponse.java
@@ -1,0 +1,18 @@
+package com.devtraces.arterest.controller.notice.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NumberOfNoticeResponse {
+
+    private Integer noticeNumber;
+
+    public static NumberOfNoticeResponse from(Integer noticeNumber) {
+        return NumberOfNoticeResponse.builder()
+                .noticeNumber(noticeNumber)
+                .build();
+    }
+}

--- a/src/main/java/com/devtraces/arterest/controller/notice/dto/ReplyNoticeDto.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/dto/ReplyNoticeDto.java
@@ -1,0 +1,45 @@
+package com.devtraces.arterest.controller.notice.dto.response;
+
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.notice.Notice;
+import com.devtraces.arterest.model.reply.Reply;
+import com.devtraces.arterest.model.user.User;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReplyNoticeDto extends NoticeListResponse {
+
+    private Long noticeId;
+    private String noticeType;
+    private String senderNickname;
+    private String senderProfileImageUrl;
+
+    private Long feedId;
+    private String feedFirstImageUrl;
+
+    private Long replyId;
+    private String replyContent;
+
+    private String createdAt;
+
+    public static ReplyNoticeDto replyNotice(Notice notice) {
+        User user = notice.getUser();
+        Feed feed = notice.getFeed();
+        Reply reply = notice.getReply();
+
+        return ReplyNoticeDto.builder()
+                .noticeId(notice.getId())
+                .noticeType(notice.getNoticeType().toString())
+                .senderNickname(user.getNickname())
+                .senderProfileImageUrl(user.getProfileImageUrl())
+                .feedId(feed.getId())
+                .feedFirstImageUrl(feed.getImageUrls().split(",")[0])
+                .replyId(reply.getId())
+                .replyContent(getShortenContent(reply.getContent()))
+                .createdAt(notice.getCreatedAt().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/devtraces/arterest/controller/notice/dto/ReplyNoticeDto.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/dto/ReplyNoticeDto.java
@@ -1,5 +1,6 @@
-package com.devtraces.arterest.controller.notice.dto.response;
+package com.devtraces.arterest.controller.notice.dto;
 
+import com.devtraces.arterest.controller.notice.dto.response.NoticeListResponse;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.notice.Notice;
 import com.devtraces.arterest.model.reply.Reply;
@@ -25,7 +26,7 @@ public class ReplyNoticeDto extends NoticeListResponse {
 
     private String createdAt;
 
-    public static ReplyNoticeDto replyNotice(Notice notice) {
+    public static ReplyNoticeDto convertToReplyNotice(Notice notice) {
         User user = notice.getUser();
         Feed feed = notice.getFeed();
         Reply reply = notice.getReply();

--- a/src/main/java/com/devtraces/arterest/controller/notice/dto/RereplyNoticeDto.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/dto/RereplyNoticeDto.java
@@ -1,5 +1,6 @@
-package com.devtraces.arterest.controller.notice.dto.response;
+package com.devtraces.arterest.controller.notice.dto;
 
+import com.devtraces.arterest.controller.notice.dto.response.NoticeListResponse;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.notice.Notice;
 import com.devtraces.arterest.model.reply.Reply;
@@ -30,7 +31,7 @@ public class RereplyNoticeDto extends NoticeListResponse {
 
     private String createdAt;
 
-    public static RereplyNoticeDto rereplyNotice(Notice notice) {
+    public static RereplyNoticeDto convertToRereplyNotice(Notice notice) {
         User user = notice.getUser();
         Feed feed = notice.getFeed();
         Reply reply = notice.getReply();

--- a/src/main/java/com/devtraces/arterest/controller/notice/dto/RereplyNoticeDto.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/dto/RereplyNoticeDto.java
@@ -1,0 +1,53 @@
+package com.devtraces.arterest.controller.notice.dto.response;
+
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.notice.Notice;
+import com.devtraces.arterest.model.reply.Reply;
+import com.devtraces.arterest.model.rereply.Rereply;
+import com.devtraces.arterest.model.user.User;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RereplyNoticeDto extends NoticeListResponse {
+
+    private Long noticeId;
+    private String noticeType;
+    private String senderNickname;
+    private String senderProfileImageUrl;
+
+    private Long feedId;
+    private String feedFirstImageUrl;
+
+    private Long replyId;
+
+    private Long rereplyId;
+    private String rereplyContent;
+
+    private String noticeTarget;
+
+    private String createdAt;
+
+    public static RereplyNoticeDto rereplyNotice(Notice notice) {
+        User user = notice.getUser();
+        Feed feed = notice.getFeed();
+        Reply reply = notice.getReply();
+        Rereply rereply = notice.getRereply();
+
+        return RereplyNoticeDto.builder()
+                .noticeId(notice.getId())
+                .noticeType(notice.getNoticeType().toString())
+                .senderNickname(user.getNickname())
+                .senderProfileImageUrl(user.getProfileImageUrl())
+                .feedId(feed.getId())
+                .feedFirstImageUrl(feed.getImageUrls().split(",")[0])
+                .replyId(reply.getId())
+                .rereplyId(rereply.getId())
+                .rereplyContent(getShortenContent(rereply.getContent()))
+                .noticeTarget(notice.getNoticeTarget().toString())
+                .createdAt(notice.getCreatedAt().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/devtraces/arterest/controller/notice/dto/response/NoticeListResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/notice/dto/response/NoticeListResponse.java
@@ -1,0 +1,18 @@
+package com.devtraces.arterest.controller.notice.dto.response;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+public class NoticeListResponse {
+
+    // 말줄임표
+    public static final String ELLIPSIS = "...";
+
+    public static final int MAX_CONTENT_LENGTH = 125;
+
+    protected static String getShortenContent(String content) {
+        return content.length() > MAX_CONTENT_LENGTH ?
+                content.substring(0, MAX_CONTENT_LENGTH) + ELLIPSIS : content;
+    }
+}

--- a/src/main/java/com/devtraces/arterest/model/notice/Notice.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/Notice.java
@@ -9,12 +9,15 @@ import com.devtraces.arterest.model.rereply.Rereply;
 import com.devtraces.arterest.model.user.User;
 import lombok.*;
 import org.hibernate.envers.AuditOverride;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
-@AuditOverride(forClass = BaseEntity.class)
+@EntityListeners(value = {AuditingEntityListener.class})
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -48,4 +51,7 @@ public class Notice extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private NoticeTarget noticeTarget;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
@@ -1,5 +1,7 @@
 package com.devtraces.arterest.model.notice;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,5 +10,5 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     Integer countAllByNoticeOwnerId(Long noticeOwnerId);
 
-    List<Notice> findALlByNoticeOwnerId(Long noticeOwnerId);
+    Page<Notice> findALlByNoticeOwnerId(Long noticeOwnerId, PageRequest pageRequest);
 }

--- a/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
@@ -3,4 +3,6 @@ package com.devtraces.arterest.model.notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    Integer countAllByNoticeOwnerId(Long noticeOwnerId);
 }

--- a/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
@@ -2,7 +2,11 @@ package com.devtraces.arterest.model.notice;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     Integer countAllByNoticeOwnerId(Long noticeOwnerId);
+
+    List<Notice> findALlByNoticeOwnerId(Long noticeOwnerId);
 }

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -3,6 +3,7 @@ package com.devtraces.arterest.service.notice;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.type.NoticeTarget;
 import com.devtraces.arterest.common.type.NoticeType;
+import com.devtraces.arterest.controller.notice.dto.NumberOfNoticeResponse;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.feed.FeedRepository;
 import com.devtraces.arterest.model.notice.Notice;
@@ -116,6 +117,12 @@ public class NoticeService {
                         NoticeType.REREPLY,
                         NoticeTarget.REPLY // 댓글 주인을 대상으로 함
                 )
+        );
+    }
+
+    public NumberOfNoticeResponse getNumberOfNotices(Long noticeOwnerId) {
+        return NumberOfNoticeResponse.from(
+                noticeRepository.countAllByNoticeOwnerId(noticeOwnerId)
         );
     }
 

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -3,9 +3,15 @@ package com.devtraces.arterest.service.notice;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.type.NoticeTarget;
 import com.devtraces.arterest.common.type.NoticeType;
+import com.devtraces.arterest.controller.notice.dto.LikeNoticeDto;
+import com.devtraces.arterest.controller.notice.dto.response.NoticeListResponse;
+import com.devtraces.arterest.controller.notice.dto.response.FollowNoticeDto;
 import com.devtraces.arterest.controller.notice.dto.NumberOfNoticeResponse;
+import com.devtraces.arterest.controller.notice.dto.response.ReplyNoticeDto;
+import com.devtraces.arterest.controller.notice.dto.response.RereplyNoticeDto;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.model.follow.FollowRepository;
 import com.devtraces.arterest.model.notice.Notice;
 import com.devtraces.arterest.model.notice.NoticeRepository;
 import com.devtraces.arterest.model.reply.Reply;
@@ -17,6 +23,9 @@ import com.devtraces.arterest.model.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
@@ -26,6 +35,7 @@ public class NoticeService {
     private final FeedRepository feedRepository;
     private final ReplyRepository replyRepository;
     private final RereplyRepository rereplyRepository;
+    private final FollowRepository followRepository;
 
     public void createLikeNotice(
             Long sendUserId, Long feedId
@@ -124,6 +134,41 @@ public class NoticeService {
         return NumberOfNoticeResponse.from(
                 noticeRepository.countAllByNoticeOwnerId(noticeOwnerId)
         );
+    }
+
+    public List<NoticeListResponse> getNoticeList(Long noticeOwnerId) {
+        List<Notice> noticesOfNoticeOwner =
+                noticeRepository.findALlByNoticeOwnerId(noticeOwnerId);
+
+        List<NoticeListResponse> noticeListResponse = new ArrayList<>();
+        for (Notice notice : noticesOfNoticeOwner) {
+            NoticeType noticeType = notice.getNoticeType();
+
+            if (noticeType.equals(NoticeType.LIKE)) {
+                noticeListResponse.add(LikeNoticeDto.likeNotice(notice));
+            }
+
+            if (noticeType.equals(NoticeType.FOLLOW)) {
+                // 요청 보낸 사람을 내가 팔로우 중인지 아닌지
+                boolean isFollowing =
+                        followRepository.isFollowing(
+                                noticeOwnerId, notice.getUser().getId()) != 0;
+
+                noticeListResponse.add(
+                        FollowNoticeDto.followNotice(notice, isFollowing)
+                );
+            }
+
+            if (noticeType.equals(NoticeType.REPLY)) {
+                noticeListResponse.add(ReplyNoticeDto.replyNotice(notice));
+            }
+
+            if (noticeType.equals(NoticeType.REREPLY)) {
+                noticeListResponse.add(RereplyNoticeDto.rereplyNotice(notice));
+            }
+        }
+
+        return noticeListResponse;
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -5,10 +5,10 @@ import com.devtraces.arterest.common.type.NoticeTarget;
 import com.devtraces.arterest.common.type.NoticeType;
 import com.devtraces.arterest.controller.notice.dto.LikeNoticeDto;
 import com.devtraces.arterest.controller.notice.dto.response.NoticeListResponse;
-import com.devtraces.arterest.controller.notice.dto.response.FollowNoticeDto;
+import com.devtraces.arterest.controller.notice.dto.FollowNoticeDto;
 import com.devtraces.arterest.controller.notice.dto.NumberOfNoticeResponse;
-import com.devtraces.arterest.controller.notice.dto.response.ReplyNoticeDto;
-import com.devtraces.arterest.controller.notice.dto.response.RereplyNoticeDto;
+import com.devtraces.arterest.controller.notice.dto.ReplyNoticeDto;
+import com.devtraces.arterest.controller.notice.dto.RereplyNoticeDto;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.feed.FeedRepository;
 import com.devtraces.arterest.model.follow.FollowRepository;
@@ -145,7 +145,7 @@ public class NoticeService {
             NoticeType noticeType = notice.getNoticeType();
 
             if (noticeType.equals(NoticeType.LIKE)) {
-                noticeListResponse.add(LikeNoticeDto.likeNotice(notice));
+                noticeListResponse.add(LikeNoticeDto.convertToLikeNotice(notice));
             }
 
             if (noticeType.equals(NoticeType.FOLLOW)) {
@@ -155,16 +155,16 @@ public class NoticeService {
                                 noticeOwnerId, notice.getUser().getId()) != 0;
 
                 noticeListResponse.add(
-                        FollowNoticeDto.followNotice(notice, isFollowing)
+                        FollowNoticeDto.convertToFollowNotice(notice, isFollowing)
                 );
             }
 
             if (noticeType.equals(NoticeType.REPLY)) {
-                noticeListResponse.add(ReplyNoticeDto.replyNotice(notice));
+                noticeListResponse.add(ReplyNoticeDto.convertToReplyNotice(notice));
             }
 
             if (noticeType.equals(NoticeType.REREPLY)) {
-                noticeListResponse.add(RereplyNoticeDto.rereplyNotice(notice));
+                noticeListResponse.add(RereplyNoticeDto.convertToRereplyNotice(notice));
             }
         }
 

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -21,6 +21,8 @@ import com.devtraces.arterest.model.rereply.RereplyRepository;
 import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -136,9 +138,15 @@ public class NoticeService {
         );
     }
 
-    public List<NoticeListResponse> getNoticeList(Long noticeOwnerId) {
-        List<Notice> noticesOfNoticeOwner =
-                noticeRepository.findALlByNoticeOwnerId(noticeOwnerId);
+    public List<NoticeListResponse> getNoticeList(
+            Long noticeOwnerId, int page, int pageSize
+    ) {
+
+        Page<Notice> noticesOfNoticeOwner =
+                noticeRepository.findALlByNoticeOwnerId(
+                        noticeOwnerId,
+                        PageRequest.of(page, pageSize)
+                );
 
         List<NoticeListResponse> noticeListResponse = new ArrayList<>();
         for (Notice notice : noticesOfNoticeOwner) {

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -120,7 +120,7 @@ public class NoticeService {
         );
     }
 
-    public NumberOfNoticeResponse getNumberOfNotices(Long noticeOwnerId) {
+    public NumberOfNoticeResponse getNumberOfNotice(Long noticeOwnerId) {
         return NumberOfNoticeResponse.from(
                 noticeRepository.countAllByNoticeOwnerId(noticeOwnerId)
         );

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -4,6 +4,7 @@ import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.exception.ErrorCode;
 import com.devtraces.arterest.common.type.NoticeTarget;
 import com.devtraces.arterest.common.type.NoticeType;
+import com.devtraces.arterest.controller.notice.dto.NumberOfNoticeResponse;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.feed.FeedRepository;
 import com.devtraces.arterest.model.notice.Notice;
@@ -532,5 +533,22 @@ class NoticeServiceTest {
 
         //then
         assertEquals(ErrorCode.REREPLY_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void success_getNumberOfNotice() {
+        //given
+        Long noticeOwnerId = 1L;
+
+        Integer numberOfNotice = 10;
+        given(noticeRepository.countAllByNoticeOwnerId(anyLong()))
+                .willReturn(numberOfNotice);
+
+        //when
+        NumberOfNoticeResponse response =
+                noticeService.getNumberOfNotice(noticeOwnerId);
+
+        //then
+        assertEquals(numberOfNotice, response.getNoticeNumber());
     }
 }

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -24,6 +24,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -597,12 +598,16 @@ class NoticeServiceTest {
                 .createdAt(LocalDateTime.now())
                 .build());
 
-        given(noticeRepository.findALlByNoticeOwnerId(anyLong()))
-                .willReturn(noticeList);
+        PageImpl<Notice> notices = new PageImpl<>(noticeList);
+
+        int page = 1;
+        int pageSize = 10;
+        given(noticeRepository.findALlByNoticeOwnerId(anyLong(), any()))
+                .willReturn(notices);
 
         //when
         List<NoticeListResponse> responseList =
-                noticeService.getNoticeList(noticeOwnerId);
+                noticeService.getNoticeList(noticeOwnerId, page, pageSize);
 
         //then
         assertEquals(numberOfNotices, responseList.size());
@@ -633,12 +638,15 @@ class NoticeServiceTest {
                 .createdAt(LocalDateTime.now())
                 .build());
 
-        given(noticeRepository.findALlByNoticeOwnerId(anyLong()))
-                .willReturn(noticeList);
+        int page = 1;
+        int pageSize = 10;
+        PageImpl<Notice> notices = new PageImpl<>(noticeList);
+        given(noticeRepository.findALlByNoticeOwnerId(anyLong(), any()))
+                .willReturn(notices);
 
         //when
         List<NoticeListResponse> responseList =
-                noticeService.getNoticeList(noticeOwnerId);
+                noticeService.getNoticeList(noticeOwnerId, page, pageSize);
 
         //then
         assertEquals(numberOfNotices, responseList.size());
@@ -669,12 +677,15 @@ class NoticeServiceTest {
                 .createdAt(LocalDateTime.now())
                 .build());
 
-        given(noticeRepository.findALlByNoticeOwnerId(anyLong()))
-                .willReturn(noticeList);
+        int page = 1;
+        int pageSize = 10;
+        PageImpl<Notice> notices = new PageImpl<>(noticeList);
+        given(noticeRepository.findALlByNoticeOwnerId(anyLong(), any()))
+                .willReturn(notices);
 
         //when
         List<NoticeListResponse> responseList =
-                noticeService.getNoticeList(noticeOwnerId);
+                noticeService.getNoticeList(noticeOwnerId, page, pageSize);
 
         //then
         assertEquals(numberOfNotices, responseList.size());
@@ -719,12 +730,15 @@ class NoticeServiceTest {
                 .createdAt(LocalDateTime.now())
                 .build());
 
-        given(noticeRepository.findALlByNoticeOwnerId(anyLong()))
-                .willReturn(noticeList);
+        int page = 1;
+        int pageSize = 10;
+        PageImpl<Notice> notices = new PageImpl<>(noticeList);
+        given(noticeRepository.findALlByNoticeOwnerId(anyLong(), any()))
+                .willReturn(notices);
 
         //when
         List<NoticeListResponse> responseList =
-                noticeService.getNoticeList(noticeOwnerId);
+                noticeService.getNoticeList(noticeOwnerId, page, pageSize);
 
         //then
         assertEquals(numberOfNotices, responseList.size());
@@ -793,12 +807,15 @@ class NoticeServiceTest {
                 .createdAt(createdAt)
                 .build());
 
-        given(noticeRepository.findALlByNoticeOwnerId(anyLong()))
-                .willReturn(noticeList);
+        int page = 1;
+        int pageSize = 10;
+        PageImpl<Notice> notices = new PageImpl<>(noticeList);
+        given(noticeRepository.findALlByNoticeOwnerId(anyLong(), any()))
+                .willReturn(notices);
 
         //when
         List<NoticeListResponse> responseList =
-                noticeService.getNoticeList(noticeOwnerId);
+                noticeService.getNoticeList(noticeOwnerId, page, pageSize);
 
         //then
         assertEquals(numberOfNotices, responseList.size());

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -3,7 +3,6 @@ package com.devtraces.arterest.service.notice;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.exception.ErrorCode;
 import com.devtraces.arterest.common.type.NoticeTarget;
-import com.devtraces.arterest.common.type.NoticeType;
 import com.devtraces.arterest.controller.notice.dto.NumberOfNoticeResponse;
 import com.devtraces.arterest.controller.notice.dto.response.NoticeListResponse;
 import com.devtraces.arterest.model.feed.Feed;
@@ -62,7 +61,6 @@ class NoticeServiceTest {
     void success_createLikeNotice() {
         //given
         Long noticeOwnerId = 1L;
-        NoticeType noticeType = LIKE;
 
         Long sendUserId = 342L;
         User user = User.builder().id(sendUserId).build();
@@ -77,7 +75,7 @@ class NoticeServiceTest {
                 .noticeOwnerId(feed.getUser().getId())
                 .user(user)
                 .feed(feed)
-                .noticeType(noticeType)
+                .noticeType(LIKE)
                 .build();
         given(noticeRepository.save(any())).willReturn(notice);
 
@@ -97,7 +95,6 @@ class NoticeServiceTest {
     @Test
     void success_createFollowNotice() {
         //given
-        NoticeType noticeType = FOLLOW;
 
         Long sendUserId = 342L;
         User user = User.builder().id(sendUserId).build();
@@ -145,13 +142,11 @@ class NoticeServiceTest {
         Reply reply = Reply.builder().id(replyId).build();
         given(replyRepository.findById(anyLong())).willReturn(Optional.of(reply));
 
-        NoticeType noticeType = REPLY;
-
         Notice notice = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
                 .user(user)
                 .feed(feed)
-                .noticeType(noticeType)
+                .noticeType(REPLY)
                 .build();
         given(noticeRepository.save(any())).willReturn(notice);
 
@@ -190,15 +185,13 @@ class NoticeServiceTest {
         Long reReplyId = 1231L;
         Rereply reReply = Rereply.builder().id(reReplyId).reply(reply).build();
 
-        NoticeType noticeType = REREPLY;
-
         Notice noticeForFeedOwner = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
                 .user(sendUser)
                 .feed(feed)
                 .reply(reply)
                 .rereply(reReply)
-                .noticeType(noticeType)
+                .noticeType(REREPLY)
                 .noticeTarget(POST)
                 .build();
 
@@ -240,15 +233,13 @@ class NoticeServiceTest {
         Long reReplyId = 1231L;
         Rereply reReply = Rereply.builder().id(reReplyId).reply(reply).build();
 
-        NoticeType noticeType = REREPLY;
-
         Notice noticeForReplyOwner = Notice.builder()
                 .noticeOwnerId(reply.getUser().getId())
                 .user(sendUser)
                 .feed(feed)
                 .reply(reply)
                 .rereply(reReply)
-                .noticeType(noticeType)
+                .noticeType(REREPLY)
                 .noticeTarget(NoticeTarget.REPLY)
                 .build();
 

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -65,7 +65,7 @@ class NoticeServiceTest {
 
         Notice notice = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
-                .sendUser(user)
+                .user(user)
                 .feed(feed)
                 .noticeType(noticeType)
                 .build();
@@ -79,7 +79,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(LIKE, captor.getValue().getNoticeType());
     }
@@ -100,7 +100,7 @@ class NoticeServiceTest {
 
         Notice notice = Notice.builder()
                 .noticeOwnerId(ownerUser.getId())
-                .sendUser(user)
+                .user(user)
                 .noticeType(noticeType)
                 .build();
         given(noticeRepository.save(any())).willReturn(notice);
@@ -113,7 +113,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(FOLLOW, captor.getValue().getNoticeType());
     }
 
@@ -139,7 +139,7 @@ class NoticeServiceTest {
 
         Notice notice = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
-                .sendUser(user)
+                .user(user)
                 .feed(feed)
                 .noticeType(noticeType)
                 .build();
@@ -153,7 +153,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(replyId, captor.getValue().getReply().getId());
         assertEquals(NoticeType.REPLY, captor.getValue().getNoticeType());
@@ -184,7 +184,7 @@ class NoticeServiceTest {
 
         Notice noticeForFeedOwner = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
-                .sendUser(sendUser)
+                .user(sendUser)
                 .feed(feed)
                 .reply(reply)
                 .rereply(reReply)
@@ -202,7 +202,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(feedOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(replyId, captor.getValue().getReply().getId());
         assertEquals(POST, captor.getValue().getNoticeTarget());
@@ -234,7 +234,7 @@ class NoticeServiceTest {
 
         Notice noticeForReplyOwner = Notice.builder()
                 .noticeOwnerId(reply.getUser().getId())
-                .sendUser(sendUser)
+                .user(sendUser)
                 .feed(feed)
                 .reply(reply)
                 .rereply(reReply)
@@ -252,7 +252,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(replyOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(replyId, captor.getValue().getReply().getId());
         assertEquals(NoticeTarget.REPLY, captor.getValue().getNoticeTarget());
@@ -430,7 +430,9 @@ class NoticeServiceTest {
         //when
         BaseException exception = assertThrows(
                 BaseException.class,
-                () -> noticeService.createReReplyNotice(sendUserId, feedId, replyId, reReplyId)
+                () -> noticeService.createReReplyNotice(
+                        sendUserId, feedId, replyId, reReplyId
+                )
         );
 
         //then
@@ -454,7 +456,9 @@ class NoticeServiceTest {
         //when
         BaseException exception = assertThrows(
                 BaseException.class,
-                () -> noticeService.createReReplyNotice(sendUserId, feedId, replyId, reReplyId)
+                () -> noticeService.createReReplyNotice(
+                        sendUserId, feedId, replyId, reReplyId
+                )
         );
 
         //then
@@ -484,7 +488,9 @@ class NoticeServiceTest {
         //when
         BaseException exception = assertThrows(
                 BaseException.class,
-                () -> noticeService.createReReplyNotice(sendUserId, feedId, replyId, reReplyId)
+                () -> noticeService.createReReplyNotice(
+                        sendUserId, feedId, replyId, reReplyId
+                )
         );
 
         //then
@@ -519,7 +525,9 @@ class NoticeServiceTest {
         //when
         BaseException exception = assertThrows(
                 BaseException.class,
-                () -> noticeService.createReReplyNotice(sendUserId, feedId, replyId, reReplyId)
+                () -> noticeService.createReReplyNotice(
+                        sendUserId, feedId, replyId, reReplyId
+                )
         );
 
         //then


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #103 

## 📍 특이사항
* 알림 리스트에 들어가는 알림들의 내용이 알림의 종류에 따라 다 다르기에 종류별로 dto 객체를 만들어야 했습니다. 
* 하지만 하나의 리스트에는 하나의 타입만 담을 수 있기에 NoticeListResponse라는 상위 클래스를 만든 후 각 NoticeDto가 이를 상속받는 구조로 설계해 하나의 리스트로 담을 수 있게 했습니다. 
    * NoticeDto는 LikeNoticeDto, FollowNoticeDto, ReplyNoticeDto, RereplyNoticeDto가 있습니다. 

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
