### PR TITLE
프로필 정보/이미지 수정 API 구현

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/user/UserController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/UserController.java
@@ -3,6 +3,7 @@ package com.devtraces.arterest.controller.user;
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
 import com.devtraces.arterest.controller.user.dto.request.PasswordUpdateRequest;
 import com.devtraces.arterest.controller.user.dto.request.UpdateProfileRequest;
+import com.devtraces.arterest.controller.user.dto.response.UpdateProfileImageResponse;
 import com.devtraces.arterest.controller.user.dto.response.UpdateProfileResponse;
 import com.devtraces.arterest.service.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import reactor.util.annotation.Nullable;
+
+import javax.validation.constraints.NotNull;
 
 @RestController
 @RequiredArgsConstructor
@@ -64,4 +67,14 @@ public class UserController {
         );
     }
 
+    @PostMapping("/profile/images/{nickname}")
+    public ApiSuccessResponse<UpdateProfileImageResponse> updateProfileImage(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable String nickname,
+            @RequestParam @NotNull MultipartFile profileImage
+    ) {
+        return ApiSuccessResponse.from(
+                userService.updateProfileImage(userId, nickname, profileImage)
+        );
+    }
 }

--- a/src/main/java/com/devtraces/arterest/controller/user/UserController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/UserController.java
@@ -2,6 +2,8 @@ package com.devtraces.arterest.controller.user;
 
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
 import com.devtraces.arterest.controller.user.dto.request.PasswordUpdateRequest;
+import com.devtraces.arterest.controller.user.dto.request.UpdateProfileRequest;
+import com.devtraces.arterest.controller.user.dto.response.UpdateProfileResponse;
 import com.devtraces.arterest.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -45,24 +47,19 @@ public class UserController {
         return ApiSuccessResponse.from(userService.getProfileByNickname(userId, nickname));
     }
 
-    @PostMapping("/profile/{nickname}")
-    public ApiSuccessResponse<?> updateProfile(
+    @PatchMapping("/profile/{nickname}")
+    public ApiSuccessResponse<UpdateProfileResponse> updateProfile(
             @AuthenticationPrincipal Long userId,
             @PathVariable String nickname,
-            @RequestParam @Nullable String updateUsername,
-            @RequestParam @Nullable String updateNickname,
-            @RequestParam @Nullable String updateDescription,
-            @RequestParam @Nullable MultipartFile updateProfileImage
-
+            @RequestBody UpdateProfileRequest request
     ) {
         return ApiSuccessResponse.from(
                 userService.updateProfile(
                         userId,
                         nickname,
-                        updateUsername,
-                        updateNickname,
-                        updateDescription,
-                        updateProfileImage
+                        request.getUsername(),
+                        request.getNickname(),
+                        request.getDescription()
                 )
         );
     }

--- a/src/main/java/com/devtraces/arterest/controller/user/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,20 @@
+package com.devtraces.arterest.controller.user.dto.request;
+
+import lombok.*;
+import reactor.util.annotation.Nullable;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateProfileRequest {
+
+    @Nullable
+    private String username;
+
+    @Nullable
+    private String nickname;
+
+    @Nullable
+    private String description;
+}

--- a/src/main/java/com/devtraces/arterest/controller/user/dto/response/UpdateProfileImageResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/dto/response/UpdateProfileImageResponse.java
@@ -1,0 +1,18 @@
+package com.devtraces.arterest.controller.user.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateProfileImageResponse {
+
+    private String profileImageUrl;
+
+    public static UpdateProfileImageResponse from(String profileImageUrl) {
+        return UpdateProfileImageResponse.builder()
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/devtraces/arterest/controller/user/dto/response/UpdateProfileImageResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/dto/response/UpdateProfileImageResponse.java
@@ -1,5 +1,6 @@
 package com.devtraces.arterest.controller.user.dto.response;
 
+import com.devtraces.arterest.model.user.User;
 import lombok.*;
 
 @Getter
@@ -10,9 +11,9 @@ public class UpdateProfileImageResponse {
 
     private String profileImageUrl;
 
-    public static UpdateProfileImageResponse from(String profileImageUrl) {
+    public static UpdateProfileImageResponse from(User user) {
         return UpdateProfileImageResponse.builder()
-                .profileImageUrl(profileImageUrl)
+                .profileImageUrl(user.getProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/devtraces/arterest/controller/user/dto/response/UpdateProfileResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/dto/response/UpdateProfileResponse.java
@@ -12,7 +12,6 @@ public class UpdateProfileResponse {
     private String username;
     private String nickname;
     private String description;
-    private String profileImageUrl;
 
 
     public static UpdateProfileResponse from(User user) {
@@ -20,7 +19,6 @@ public class UpdateProfileResponse {
                 .username(user.getUsername())
                 .nickname(user.getNickname())
                 .description(user.getDescription())
-                .profileImageUrl(user.getProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/devtraces/arterest/service/user/UserService.java
+++ b/src/main/java/com/devtraces/arterest/service/user/UserService.java
@@ -1,13 +1,10 @@
 package com.devtraces.arterest.service.user;
 
+import com.devtraces.arterest.controller.user.dto.response.*;
 import com.devtraces.arterest.model.follow.FollowRepository;
 import com.devtraces.arterest.service.s3.S3Service;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.exception.ErrorCode;
-import com.devtraces.arterest.controller.user.dto.response.EmailCheckResponse;
-import com.devtraces.arterest.controller.user.dto.response.NicknameCheckResponse;
-import com.devtraces.arterest.controller.user.dto.response.ProfileByNicknameResponse;
-import com.devtraces.arterest.controller.user.dto.response.UpdateProfileResponse;
 import com.devtraces.arterest.model.feed.FeedRepository;
 import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
@@ -26,6 +23,7 @@ public class UserService {
     private final FeedRepository feedRepository;
     private final FollowRepository followRepository;
     private final PasswordEncoder passwordEncoder;
+    private final S3Service s3Service;
 
     public EmailCheckResponse checkEmail(String email) {
 
@@ -101,6 +99,16 @@ public class UserService {
         if (updateDescription != null) { user.setDescription(updateDescription); }
 
         return UpdateProfileResponse.from(userRepository.save(user));
+    }
+
+    public UpdateProfileImageResponse updateProfileImage(
+            Long userId, String nickname, MultipartFile profileImage
+    ) {
+        User user = getUserById(userId);
+
+        if (!user.getNickname().equals(nickname)) { throw BaseException.FORBIDDEN; }
+
+        return UpdateProfileImageResponse.from(s3Service.uploadImage(profileImage));
     }
 
     private User getUserById(Long userId) {

--- a/src/main/java/com/devtraces/arterest/service/user/UserService.java
+++ b/src/main/java/com/devtraces/arterest/service/user/UserService.java
@@ -108,7 +108,9 @@ public class UserService {
 
         if (!user.getNickname().equals(nickname)) { throw BaseException.FORBIDDEN; }
 
-        return UpdateProfileImageResponse.from(s3Service.uploadImage(profileImage));
+        user.setProfileImageUrl(s3Service.uploadImage(profileImage));
+
+        return UpdateProfileImageResponse.from(userRepository.save(user));
     }
 
     private User getUserById(Long userId) {

--- a/src/main/java/com/devtraces/arterest/service/user/UserService.java
+++ b/src/main/java/com/devtraces/arterest/service/user/UserService.java
@@ -26,7 +26,6 @@ public class UserService {
     private final FeedRepository feedRepository;
     private final FollowRepository followRepository;
     private final PasswordEncoder passwordEncoder;
-    private final S3Service s3Service;
 
     public EmailCheckResponse checkEmail(String email) {
 
@@ -88,7 +87,7 @@ public class UserService {
     public UpdateProfileResponse updateProfile(
             Long userId, String nickname,
             String updateUsername, String updateNickname,
-            String updateDescription, MultipartFile updateProfileImage
+            String updateDescription
             ) {
         User user = getUserById(userId);
 
@@ -100,10 +99,6 @@ public class UserService {
         if (updateNickname != null) { user.setNickname(updateNickname); }
 
         if (updateDescription != null) { user.setDescription(updateDescription); }
-
-        if (updateProfileImage != null) {
-            user.setProfileImageUrl(s3Service.uploadImage(updateProfileImage));
-        }
 
         return UpdateProfileResponse.from(userRepository.save(user));
     }

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -65,7 +65,7 @@ class NoticeServiceTest {
 
         Notice notice = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
-                .sendUser(user)
+                .user(user)
                 .feed(feed)
                 .noticeType(noticeType)
                 .build();
@@ -79,7 +79,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(LIKE, captor.getValue().getNoticeType());
     }
@@ -100,7 +100,7 @@ class NoticeServiceTest {
 
         Notice notice = Notice.builder()
                 .noticeOwnerId(ownerUser.getId())
-                .sendUser(user)
+                .user(user)
                 .noticeType(noticeType)
                 .build();
         given(noticeRepository.save(any())).willReturn(notice);
@@ -113,7 +113,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(FOLLOW, captor.getValue().getNoticeType());
     }
 
@@ -139,7 +139,7 @@ class NoticeServiceTest {
 
         Notice notice = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
-                .sendUser(user)
+                .user(user)
                 .feed(feed)
                 .noticeType(noticeType)
                 .build();
@@ -153,7 +153,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(replyId, captor.getValue().getReply().getId());
         assertEquals(NoticeType.REPLY, captor.getValue().getNoticeType());
@@ -184,7 +184,7 @@ class NoticeServiceTest {
 
         Notice noticeForFeedOwner = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
-                .sendUser(sendUser)
+                .user(sendUser)
                 .feed(feed)
                 .reply(reply)
                 .rereply(reReply)
@@ -202,7 +202,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(feedOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(replyId, captor.getValue().getReply().getId());
         assertEquals(POST, captor.getValue().getNoticeTarget());
@@ -234,7 +234,7 @@ class NoticeServiceTest {
 
         Notice noticeForReplyOwner = Notice.builder()
                 .noticeOwnerId(reply.getUser().getId())
-                .sendUser(sendUser)
+                .user(sendUser)
                 .feed(feed)
                 .reply(reply)
                 .rereply(reReply)
@@ -252,7 +252,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(replyOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(replyId, captor.getValue().getReply().getId());
         assertEquals(NoticeTarget.REPLY, captor.getValue().getNoticeTarget());

--- a/src/test/java/com/devtraces/arterest/service/user/UserServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/user/UserServiceTest.java
@@ -259,16 +259,13 @@ class UserServiceTest {
         String updateUsername = "updateUsername";
         String updateNickname = "updateNickname";
         String updateDescription = "updateDescription";
-        String updateProfileImageUrl = "updateProfileImageUrl";
-        MultipartFile multipartFile =
-                new MockMultipartFile("file", "fileContent".getBytes());
+
         User user = User.builder()
                 .id(1L)
                 .nickname(nickname)
                 .build();
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
-        given(s3Service.uploadImage(multipartFile)).willReturn(updateProfileImageUrl);
         given(userRepository.save(any())).willReturn(user);
 
         ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
@@ -276,7 +273,7 @@ class UserServiceTest {
         //when
        userService.updateProfile(
                 user.getId(), nickname, updateUsername,
-                updateNickname, updateDescription, multipartFile
+                updateNickname, updateDescription
         );
 
         //then
@@ -295,8 +292,6 @@ class UserServiceTest {
         String updateUsername = "updateUsername";
         String updateNickname = "updateNickname";
         String updateDescription = "updateDescription";
-        MultipartFile multipartFile =
-                new MockMultipartFile("file", "fileContent".getBytes());
 
         given(userRepository.findById(anyLong())).willReturn(Optional.empty());
 
@@ -304,7 +299,7 @@ class UserServiceTest {
         BaseException exception = assertThrows(BaseException.class,
                 () -> userService.updateProfile(
                         anyLong(), nickname, updateUsername,
-                        updateNickname, updateDescription, multipartFile
+                        updateNickname, updateDescription
                 )
         );
 
@@ -321,8 +316,7 @@ class UserServiceTest {
         String updateUsername = "updateUsername";
         String updateNickname = "updateNickname";
         String updateDescription = "updateDescription";
-        MultipartFile multipartFile =
-                new MockMultipartFile("file", "fileContent".getBytes());
+
         User notOwner = User.builder()
                 .id(2L)
                 .nickname(notOwnerNickname)
@@ -334,7 +328,7 @@ class UserServiceTest {
         BaseException exception = assertThrows(BaseException.class,
                 () -> userService.updateProfile(
                         notOwner.getId(), ownerNickname, updateUsername,
-                        updateNickname, updateDescription, multipartFile
+                        updateNickname, updateDescription
                 )
         );
 

--- a/src/test/java/com/devtraces/arterest/service/user/UserServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/user/UserServiceTest.java
@@ -17,9 +17,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -316,7 +314,6 @@ class UserServiceTest {
         String updateUsername = "updateUsername";
         String updateNickname = "updateNickname";
         String updateDescription = "updateDescription";
-
         User notOwner = User.builder()
                 .id(2L)
                 .nickname(notOwnerNickname)


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #110 

## 📍 특이사항
* 기존에 하나의 API로 프로필 정보와 이미지를 수정했지만, 로직이 복잡해서 둘을 분리했습니다. 
* 프로필 정보 수정 API에서는 username, nickname, description 중 변경된 값만 요청이 됩니다.
* 프로필 이미지 수정 API에서는 필수로 수정하고자 하는 이미지 파일 1개만 요청 됩니다.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
