### PR TITLE
프로필 이미지 삭제 API 구현

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/user/UserController.java
+++ b/src/main/java/com/devtraces/arterest/controller/user/UserController.java
@@ -77,4 +77,13 @@ public class UserController {
                 userService.updateProfileImage(userId, nickname, profileImage)
         );
     }
+
+    @DeleteMapping("/profile/images/{nickname}")
+    public ApiSuccessResponse<?> deleteProfileImage(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable String nickname
+    ) {
+        userService.deleteProfileImage(userId, nickname);
+        return ApiSuccessResponse.NO_DATA_RESPONSE;
+    }
 }

--- a/src/main/java/com/devtraces/arterest/service/user/UserService.java
+++ b/src/main/java/com/devtraces/arterest/service/user/UserService.java
@@ -11,6 +11,7 @@ import com.devtraces.arterest.model.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
@@ -111,6 +112,16 @@ public class UserService {
         user.setProfileImageUrl(s3Service.uploadImage(profileImage));
 
         return UpdateProfileImageResponse.from(userRepository.save(user));
+    }
+
+    // 프로필 이미지 삭제는 사용자의 프로필 이미지를 null로 수정하는 것으로 진행
+    public void deleteProfileImage(Long userId, String nickname) {
+        User user = getUserById(userId);
+
+        if (!user.getNickname().equals(nickname)) { throw BaseException.FORBIDDEN; }
+
+        user.setProfileImageUrl(null);
+        userRepository.save(user);
     }
 
     private User getUserById(Long userId) {

--- a/src/main/java/com/devtraces/arterest/service/user/UserService.java
+++ b/src/main/java/com/devtraces/arterest/service/user/UserService.java
@@ -11,7 +11,6 @@ import com.devtraces.arterest.model.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
@@ -75,7 +74,7 @@ public class UserService {
         Integer followerNumber = followRepository.countAllByFollowingId(targetUser.getId());
         Integer followingNumber = targetUser.getFollowList().size();
         boolean isFollowing = followRepository.isFollowing(
-                user.getId(), targetUser.getId()) == 0 ? false : true;
+                user.getId(), targetUser.getId()) != 0;
 
         return ProfileByNicknameResponse.from(
                 targetUser, totalFeedNumber,
@@ -125,9 +124,7 @@ public class UserService {
     }
 
     private User getUserById(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(
-                () -> BaseException.USER_NOT_FOUND
-        );
-        return user;
+        return userRepository.findById(userId).orElseThrow(
+                () -> BaseException.USER_NOT_FOUND);
     }
 }

--- a/src/test/java/com/devtraces/arterest/service/user/UserServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/user/UserServiceTest.java
@@ -55,7 +55,7 @@ class UserServiceTest {
 
         EmailCheckResponse response = userService.checkEmail(email);
 
-        assertEquals(true, response.isDuplicatedEmail());
+        assertTrue(response.isDuplicatedEmail());
     }
 
     @Test
@@ -66,7 +66,7 @@ class UserServiceTest {
 
         EmailCheckResponse response = userService.checkEmail(email);
 
-        assertEquals(false, response.isDuplicatedEmail());
+        assertFalse(response.isDuplicatedEmail());
     }
 
     @Test
@@ -78,7 +78,7 @@ class UserServiceTest {
 
         NicknameCheckResponse response = userService.checkNickname(nickname);
 
-        assertEquals(true, response.isDuplicatedNickname());
+        assertTrue(response.isDuplicatedNickname());
     }
 
     @Test
@@ -89,7 +89,7 @@ class UserServiceTest {
 
         NicknameCheckResponse response = userService.checkNickname(nickname);
 
-        assertEquals(false, response.isDuplicatedNickname());
+        assertFalse(response.isDuplicatedNickname());
     }
 
     @Test


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #110 

## 📍 특이사항
* 사용자의 프로필 이미지 삭제는 이미지 값을 null로 변경하는 것을 의미합니다. 

## 📍 테스트
- [x] API Test
- [x] 단위 테스트