### PR TITLE
JWT Access Token 발급 방식 변경

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.devtraces.arterest.common.jwt;
 
 import static com.devtraces.arterest.common.jwt.JwtProperties.AUTHORIZATION_HEADER;
 import static com.devtraces.arterest.common.jwt.JwtProperties.TOKEN_PREFIX;
+import static com.devtraces.arterest.common.jwt.JwtProvider.ACCESS_TOKEN_COOKIE_NAME;
 
 import com.devtraces.arterest.common.exception.ErrorCode;
 import com.devtraces.arterest.service.auth.util.TokenRedisUtil;
@@ -13,9 +14,12 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -57,10 +61,14 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
 	// Request Header 에서 JWT 토큰 정보 추출
 	private String resolveToken(HttpServletRequest request) {
-		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_PREFIX)) {
-			return bearerToken.substring(TOKEN_PREFIX.length() + 1);
-		}
+
+		String cookies = request.getHeader(HttpHeaders.COOKIE);
+		if(cookies == null) return null;
+		String accessToken = cookies.split("; ")[0]
+			.replace(ACCESS_TOKEN_COOKIE_NAME + "=", "");
+
+		if (accessToken != null) return accessToken;
+
 		return null;
 	}
 }

--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
@@ -85,8 +85,8 @@ public class JwtProvider {
 			.httpOnly(true)
 			.path("/")
 			.maxAge(CREATE_AGE)
-			.secure(true)
-			.sameSite(SameSite.NONE.attributeValue())
+//			.secure(true)
+//			.sameSite(SameSite.NONE.attributeValue())
 			.build();
 
 		return cookie;

--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
@@ -29,6 +29,9 @@ import org.springframework.stereotype.Component;
 public class JwtProvider {
 
 	public static final String REFRESH_TOKEN_SUBJECT_PREFIX = "refresh:";
+
+	public static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+	public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 	private static final int CREATE_AGE = 7 * 24 * 60 * 60;
 
 	private final UserDetailsService userDetailsService;
@@ -71,14 +74,14 @@ public class JwtProvider {
 		tokenRedisUtil.setRefreshTokenValue(userId, refreshToken, refreshTokenExpiredIn);
 
 		return TokenDto.builder()
-			.accessToken(accessToken)
-			.cookie(generateCookie(refreshToken))
+			.accessTokenCookie(generateCookie(accessToken, ACCESS_TOKEN_COOKIE_NAME))
+			.refreshTokenCookie(generateCookie(refreshToken, REFRESH_TOKEN_COOKIE_NAME))
 			.build();
 	}
 
-	private ResponseCookie generateCookie(String refreshToken) {
+	private ResponseCookie generateCookie(String token, String name) {
 
-		ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+		ResponseCookie cookie = ResponseCookie.from(name, token)
 			.httpOnly(true)
 			.path("/")
 			.maxAge(CREATE_AGE)

--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
@@ -85,8 +85,8 @@ public class JwtProvider {
 			.httpOnly(true)
 			.path("/")
 			.maxAge(CREATE_AGE)
-//			.secure(true)
-//			.sameSite(SameSite.NONE.attributeValue())
+			.secure(true)
+			.sameSite(SameSite.NONE.attributeValue())
 			.build();
 
 		return cookie;

--- a/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
@@ -1,15 +1,9 @@
 package com.devtraces.arterest.common.jwt.controller;
 
-import static com.devtraces.arterest.common.jwt.JwtProperties.TOKEN_PREFIX;
-import static com.devtraces.arterest.controller.auth.AuthController.ACCESS_TOKEN_PREFIX;
-import static com.devtraces.arterest.controller.auth.AuthController.SET_COOKIE;
-
 import com.devtraces.arterest.common.jwt.service.JwtService;
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
-import java.util.HashMap;
-
 import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
-import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,10 +32,10 @@ public class JwtController {
 		TokenWithNicknameDto dto = jwtService.reissue(bearerToken, refreshToken);
 
 		HashMap hashMap = new HashMap();
-		hashMap.put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + dto.getAccessToken());
 		hashMap.put("nickname", dto.getNickname());
 
-		response.setHeader(HttpHeaders.SET_COOKIE, dto.getCookie().toString());
+		response.setHeader(HttpHeaders.SET_COOKIE, dto.getAcceesTokenCookie().toString());
+		response.setHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
 
 		return ResponseEntity.ok()
 			.body(ApiSuccessResponse.from(hashMap));

--- a/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
@@ -1,5 +1,8 @@
 package com.devtraces.arterest.common.jwt.controller;
 
+import static com.devtraces.arterest.common.jwt.JwtProvider.ACCESS_TOKEN_COOKIE_NAME;
+import static com.devtraces.arterest.common.jwt.JwtProvider.REFRESH_TOKEN_COOKIE_NAME;
+
 import com.devtraces.arterest.common.jwt.service.JwtService;
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
 import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
@@ -25,7 +28,7 @@ public class JwtController {
 
 	@PostMapping("/reissue")
 	public ResponseEntity<ApiSuccessResponse<?>> reissue(
-		@CookieValue("refreshToken") String refreshToken,
+		@CookieValue(REFRESH_TOKEN_COOKIE_NAME) String refreshToken,
 		HttpServletResponse response
 	) {
 		TokenWithNicknameDto dto = jwtService.reissue(refreshToken);

--- a/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
@@ -25,11 +25,10 @@ public class JwtController {
 
 	@PostMapping("/reissue")
 	public ResponseEntity<ApiSuccessResponse<?>> reissue(
-		@RequestHeader("authorization") String bearerToken,
 		@CookieValue("refreshToken") String refreshToken,
 		HttpServletResponse response
 	) {
-		TokenWithNicknameDto dto = jwtService.reissue(bearerToken, refreshToken);
+		TokenWithNicknameDto dto = jwtService.reissue(refreshToken);
 
 		HashMap hashMap = new HashMap();
 		hashMap.put("nickname", dto.getNickname());

--- a/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/controller/JwtController.java
@@ -36,8 +36,8 @@ public class JwtController {
 		HashMap hashMap = new HashMap();
 		hashMap.put("nickname", dto.getNickname());
 
-		response.setHeader(HttpHeaders.SET_COOKIE, dto.getAcceesTokenCookie().toString());
-		response.setHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
+		response.addHeader(HttpHeaders.SET_COOKIE, dto.getAcceesTokenCookie().toString());
+		response.addHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
 
 		return ResponseEntity.ok()
 			.body(ApiSuccessResponse.from(hashMap));

--- a/src/main/java/com/devtraces/arterest/common/jwt/dto/TokenDto.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/dto/TokenDto.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseCookie;
 @AllArgsConstructor
 public class TokenDto {
 
-	private String accessToken;
-	private ResponseCookie cookie;
+	private ResponseCookie accessTokenCookie;
+	private ResponseCookie refreshTokenCookie;
 
 }

--- a/src/main/java/com/devtraces/arterest/common/jwt/service/JwtService.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/service/JwtService.java
@@ -24,16 +24,12 @@ public class JwtService {
 	private final UserRepository userRepository;
 
 	@Transactional
-	public TokenWithNicknameDto reissue(String bearerToken, String refreshToken) {
+	public TokenWithNicknameDto reissue(String refreshToken) {
 
-		String accessToken = "";
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_PREFIX)) {
-			accessToken = bearerToken.substring(TOKEN_PREFIX.length() + 1);
-		}
+		validateTokens(refreshToken);
 
 		Long userId = Long.parseLong(jwtProvider.getUserId(refreshToken)
 			.replace(REFRESH_TOKEN_SUBJECT_PREFIX, ""));
-		validateTokens(accessToken, refreshToken, userId);
 
 		if (!tokenRedisUtil.hasSameRefreshToken(userId, refreshToken)) {
 			throw BaseException.EXPIRED_OR_PREVIOUS_REFRESH_TOKEN;
@@ -48,12 +44,7 @@ public class JwtService {
 		);
 	}
 
-	private void validateTokens(String accessToken, String refreshToken, Long userId) {
-		// 토큰 재발행의 경우 Access Token이 만료되어야 한다.
-		if (!jwtProvider.isExpiredToken(accessToken)) {
-			throw BaseException.NOT_EXPIRED_ACCESS_TOKEN;
-		}
-
+	private void validateTokens(String refreshToken) {
 		if (jwtProvider.isExpiredToken(refreshToken)) {
 			throw BaseException.EXPIRED_OR_PREVIOUS_REFRESH_TOKEN;
 		}

--- a/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
@@ -78,8 +78,8 @@ public class AuthController {
 		HashMap hashMap = new HashMap();
 		hashMap.put("nickname", dto.getNickname());
 
-		response.setHeader(HttpHeaders.SET_COOKIE, dto.getAcceesTokenCookie().toString());
-		response.setHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
+		response.addHeader(HttpHeaders.SET_COOKIE, dto.getAcceesTokenCookie().toString());
+		response.addHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
 
 		return ResponseEntity.ok()
 				.body(ApiSuccessResponse.from(hashMap));

--- a/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
@@ -3,28 +3,30 @@ package com.devtraces.arterest.controller.auth;
 import static com.devtraces.arterest.common.jwt.JwtProperties.TOKEN_PREFIX;
 
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
+import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
 import com.devtraces.arterest.controller.auth.dto.request.MailAuthKeyCheckRequest;
-import com.devtraces.arterest.controller.auth.dto.response.MailAuthKeyCheckResponse;
 import com.devtraces.arterest.controller.auth.dto.request.MailAuthKeyRequest;
+import com.devtraces.arterest.controller.auth.dto.request.SignInRequest;
+import com.devtraces.arterest.controller.auth.dto.response.MailAuthKeyCheckResponse;
+import com.devtraces.arterest.controller.auth.dto.response.UserRegistrationResponse;
 import com.devtraces.arterest.controller.user.dto.request.PasswordCheckRequest;
 import com.devtraces.arterest.controller.user.dto.response.PasswordCheckResponse;
-import com.devtraces.arterest.controller.auth.dto.request.SignInRequest;
-import com.devtraces.arterest.controller.auth.dto.request.UserRegistrationRequest;
-import com.devtraces.arterest.controller.auth.dto.response.UserRegistrationResponse;
 import com.devtraces.arterest.service.auth.AuthService;
 import java.util.HashMap;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
-
-import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import reactor.util.annotation.Nullable;
 
@@ -33,8 +35,6 @@ import reactor.util.annotation.Nullable;
 @RequestMapping("/api/auth")
 public class AuthController {
 	private final AuthService authService;
-	public static final String SET_COOKIE = "Set-Cookie";
-	public static final String ACCESS_TOKEN_PREFIX = "accessToken";
 
 	@PostMapping("sign-up")
 	public ApiSuccessResponse<UserRegistrationResponse> signUp(
@@ -76,10 +76,10 @@ public class AuthController {
 		);
 
 		HashMap hashMap = new HashMap();
-		hashMap.put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + dto.getAccessToken());
 		hashMap.put("nickname", dto.getNickname());
 
-		response.setHeader(HttpHeaders.SET_COOKIE, dto.getCookie().toString());
+		response.setHeader(HttpHeaders.SET_COOKIE, dto.getAcceesTokenCookie().toString());
+		response.setHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
 
 		return ResponseEntity.ok()
 				.body(ApiSuccessResponse.from(hashMap));

--- a/src/main/java/com/devtraces/arterest/controller/auth/OauthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/OauthController.java
@@ -1,11 +1,10 @@
 package com.devtraces.arterest.controller.auth;
 
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
+import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
 import com.devtraces.arterest.controller.auth.dto.request.OauthKakaoSignInRequest;
 import com.devtraces.arterest.service.auth.OauthService;
 import java.util.HashMap;
-
-import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -14,10 +13,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import static com.devtraces.arterest.common.jwt.JwtProperties.TOKEN_PREFIX;
-import static com.devtraces.arterest.controller.auth.AuthController.ACCESS_TOKEN_PREFIX;
-import static com.devtraces.arterest.controller.auth.AuthController.SET_COOKIE;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,10 +30,10 @@ public class OauthController {
                 oauthService.oauthKakaoSignIn(request.getAccessTokenFromKakao());
 
         HashMap hashMap = new HashMap();
-        hashMap.put(ACCESS_TOKEN_PREFIX, TOKEN_PREFIX + " " + dto.getAccessToken());
         hashMap.put("nickname", dto.getNickname());
 
-        response.setHeader(HttpHeaders.SET_COOKIE, dto.getCookie().toString());
+        response.setHeader(HttpHeaders.SET_COOKIE, dto.getAcceesTokenCookie().toString());
+        response.setHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
 
         return ResponseEntity.ok()
             .body(ApiSuccessResponse.from(hashMap));

--- a/src/main/java/com/devtraces/arterest/controller/auth/OauthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/OauthController.java
@@ -32,8 +32,8 @@ public class OauthController {
         HashMap hashMap = new HashMap();
         hashMap.put("nickname", dto.getNickname());
 
-        response.setHeader(HttpHeaders.SET_COOKIE, dto.getAcceesTokenCookie().toString());
-        response.setHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, dto.getAcceesTokenCookie().toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, dto.getRefreshTokenCookie().toString());
 
         return ResponseEntity.ok()
             .body(ApiSuccessResponse.from(hashMap));

--- a/src/main/java/com/devtraces/arterest/controller/auth/dto/TokenWithNicknameDto.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/dto/TokenWithNicknameDto.java
@@ -16,14 +16,14 @@ import org.springframework.http.ResponseCookie;
 public class TokenWithNicknameDto {
 
     private String nickname;
-    private String accessToken;
-    private ResponseCookie cookie;
+    private ResponseCookie acceesTokenCookie;
+    private ResponseCookie refreshTokenCookie;
 
     public static TokenWithNicknameDto from(String nickname, TokenDto tokenDto) {
         return TokenWithNicknameDto.builder()
                 .nickname(nickname)
-                .accessToken(tokenDto.getAccessToken())
-                .cookie(tokenDto.getCookie())
+                .acceesTokenCookie(tokenDto.getAccessTokenCookie())
+                .refreshTokenCookie(tokenDto.getRefreshTokenCookie())
                 .build();
     }
 }

--- a/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
@@ -41,13 +41,12 @@ public class LikeController {
 
     @GetMapping("/feeds/like/{feedId}")
     public ApiSuccessResponse<List<LikeResponse>> getLikedUserList(
-        @AuthenticationPrincipal Long userId,
         @PathVariable Long feedId,
         @RequestParam int page,
         @RequestParam(required = false, defaultValue = "10") int pageSize
     ){
         return ApiSuccessResponse.from(
-            likeService.getLikedUserList(userId, feedId, page, pageSize)
+            likeService.getLikedUserList(feedId, page, pageSize)
         );
     }
 

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -55,7 +55,7 @@ public class LikeService {
 
     @Transactional(readOnly = true)
     public List<LikeResponse> getLikedUserList(
-        Long userId, Long feedId, int page, int pageSize
+        Long feedId, int page, int pageSize
     ) {
         validateFeedExistence(feedId);
         PageRequest pageRequest = PageRequest.of(page, pageSize);

--- a/src/test/java/com/devtraces/arterest/common/jwt/JwtProviderTest.java
+++ b/src/test/java/com/devtraces/arterest/common/jwt/JwtProviderTest.java
@@ -61,12 +61,12 @@ class JwtProviderTest {
 		TokenDto tokenDto = jwtProvider.generateAccessTokenAndRefreshToken(1L);
 
 		Claims accessTokenBody = Jwts.parserBuilder().setSigningKey(secretKey).build()
-			.parseClaimsJws(tokenDto.getAccessToken()).getBody();
+			.parseClaimsJws(tokenDto.getAccessTokenCookie().getValue()).getBody();
 		assertEquals("1", accessTokenBody.getSubject());
 		assertTrue(accessTokenBody.getExpiration().after(new Date()));
 
 		Claims refreshTokenBody = Jwts.parserBuilder().setSigningKey(secretKey).build()
-			.parseClaimsJws(tokenDto.getCookie().getValue()).getBody();
+			.parseClaimsJws(tokenDto.getRefreshTokenCookie().getValue()).getBody();
 		assertEquals(JwtProvider.REFRESH_TOKEN_SUBJECT_PREFIX + "1", refreshTokenBody.getSubject());
 		assertTrue(refreshTokenBody.getExpiration().after(new Date()));
 	}
@@ -78,7 +78,7 @@ class JwtProviderTest {
 			.willReturn(mockUserDetails);
 
 		TokenDto tokenDto = jwtProvider.generateAccessTokenAndRefreshToken(1L);
-		String accessToken = tokenDto.getAccessToken();
+		String accessToken = tokenDto.getAccessTokenCookie().getValue();
 
 		Authentication authentication = jwtProvider.getAuthentication(accessToken);
 
@@ -88,7 +88,7 @@ class JwtProviderTest {
 	@Test
 	void testGetExpiredDate() {
 		TokenDto tokenDto = jwtProvider.generateAccessTokenAndRefreshToken(1L);
-		String accessToken = tokenDto.getAccessToken();
+		String accessToken = tokenDto.getAccessTokenCookie().getValue();
 
 		Date expiredDate = jwtProvider.getExpiredDate(accessToken);
 
@@ -113,7 +113,7 @@ class JwtProviderTest {
 	@Test
 	void testIsExpiredTokenByNotExpiredToken() {
 		TokenDto tokenDto = jwtProvider.generateAccessTokenAndRefreshToken(1L);
-		String accessToken = tokenDto.getAccessToken();
+		String accessToken = tokenDto.getAccessTokenCookie().getValue();
 
 		boolean isExpiredToken = jwtProvider.isExpiredToken(accessToken);
 

--- a/src/test/java/com/devtraces/arterest/common/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/common/jwt/service/JwtServiceTest.java
@@ -1,18 +1,20 @@
 package com.devtraces.arterest.common.jwt.service;
 
+import static com.devtraces.arterest.common.jwt.JwtProvider.REFRESH_TOKEN_SUBJECT_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.jwt.JwtProvider;
 import com.devtraces.arterest.common.jwt.dto.TokenDto;
 import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
-import com.devtraces.arterest.service.auth.AuthService;
+import com.devtraces.arterest.model.user.User;
+import com.devtraces.arterest.model.user.UserRepository;
 import com.devtraces.arterest.service.auth.util.TokenRedisUtil;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,9 +28,9 @@ class JwtServiceTest {
 	@Mock
 	private JwtProvider jwtProvider;
 	@Mock
-	private AuthService authService;
-	@Mock
 	private TokenRedisUtil tokenRedisUtil;
+	@Mock
+	private UserRepository userRepository;
 
 	@InjectMocks
 	private JwtService jwtService;
@@ -36,68 +38,35 @@ class JwtServiceTest {
 	@Test
 	void testReissue() {
 		TokenDto mockTokenDto = TokenDto.builder()
-			.accessToken("access-token2")
-			.cookie(ResponseCookie.from("freshToken", "refresh-token2").build())
+			.accessTokenCookie(ResponseCookie.from("accessToken", "access-token2").build())
+			.refreshTokenCookie(ResponseCookie.from("refreshToken", "refresh-token2").build())
 			.build();
 		given(jwtProvider.getUserId(anyString()))
 			.willReturn("1");
-		given(jwtProvider.isExpiredToken("access-token"))
-			.willReturn(true);
 		given(jwtProvider.isExpiredToken("refresh-token"))
 			.willReturn(false);
 		given(tokenRedisUtil.hasSameRefreshToken(anyLong(), anyString()))
 			.willReturn(true);
+		given(userRepository.findById(anyLong()))
+			.willReturn(Optional.ofNullable(User.builder().build()));
 		given(jwtProvider.generateAccessTokenAndRefreshToken(anyLong()))
 			.willReturn(mockTokenDto);
 
-		TokenWithNicknameDto dto = jwtService.reissue("access-token", "refresh-token");
+		TokenWithNicknameDto dto = jwtService.reissue("refresh-token");
 
-		assertEquals("access-token2", dto.getAccessToken());
-		assertEquals("refresh-token2", dto.getCookie().getValue());
-	}
-
-	// 유효하지 않은 토큰인 경우
-	@Test
-	void testReissueByInvalidToken() {
-		given(jwtProvider.getUserId(anyString()))
-			.willReturn("1");
-		given(jwtProvider.isExpiredToken(anyString()))
-			.willThrow(BaseException.INVALID_TOKEN);
-
-		BaseException exception = assertThrows(BaseException.class,
-			() -> jwtService.reissue("access-token", "refresh-token"));
-
-		assertEquals(BaseException.INVALID_TOKEN, exception);
-	}
-
-	// access token이 만료되지 않은 경우
-	@Test
-	void testReissueByNotExpiredAccessToken() {
-		given(jwtProvider.getUserId(anyString()))
-			.willReturn("1");
-		given(jwtProvider.isExpiredToken("access-token"))
-			.willReturn(false);
-		willDoNothing()
-			.given(authService).signOut(anyLong(), anyString());
-
-		BaseException exception = assertThrows(BaseException.class,
-			() -> jwtService.reissue( "access-token", "refresh-token"));
-
-		assertEquals(BaseException.NOT_EXPIRED_ACCESS_TOKEN, exception);
+		assertEquals("access-token2", dto.getAcceesTokenCookie().getValue());
+		assertEquals("refresh-token2", dto.getRefreshTokenCookie().getValue());
 	}
 
 	// refresh token이 만료된 경우
 	@Test
 	void testReissueByExpiredRefreshToken() {
-		given(jwtProvider.getUserId(anyString()))
-			.willReturn("1");
-		given(jwtProvider.isExpiredToken("access-token"))
-			.willReturn(true);
+
 		given(jwtProvider.isExpiredToken("refresh-token"))
 			.willReturn(true);
 
 		BaseException exception = assertThrows(BaseException.class,
-			() -> jwtService.reissue( "access-token", "refresh-token"));
+			() -> jwtService.reissue( "refresh-token"));
 
 		assertEquals(BaseException.EXPIRED_OR_PREVIOUS_REFRESH_TOKEN, exception);
 	}
@@ -105,18 +74,35 @@ class JwtServiceTest {
 	// Redis에 저장된 Refresh Token과 정보가 다른 경우
 	@Test
 	void testReissueByDifferentRefreshToken() {
-		given(jwtProvider.getUserId(anyString()))
-			.willReturn("1");
-		given(jwtProvider.isExpiredToken("access-token"))
-			.willReturn(true);
 		given(jwtProvider.isExpiredToken("refresh-token"))
 			.willReturn(false);
+		given(jwtProvider.getUserId(anyString()))
+			.willReturn(REFRESH_TOKEN_SUBJECT_PREFIX + "1");
 		given(tokenRedisUtil.hasSameRefreshToken(anyLong(), anyString()))
 			.willReturn(false);
 
 		BaseException exception = assertThrows(BaseException.class,
-			() -> jwtService.reissue("access-token", "refresh-token"));
+			() -> jwtService.reissue("refresh-token"));
 
 		assertEquals(BaseException.EXPIRED_OR_PREVIOUS_REFRESH_TOKEN, exception);
+	}
+
+	// user 가 존재하지 않는 경우
+	@Test
+	void testReissueByUserNotFound() {
+		given(jwtProvider.isExpiredToken("refresh-token"))
+			.willReturn(false);
+		given(jwtProvider.getUserId(anyString()))
+			.willReturn(REFRESH_TOKEN_SUBJECT_PREFIX + "1");
+		given(tokenRedisUtil.hasSameRefreshToken(anyLong(), anyString()))
+			.willReturn(true);
+		given(userRepository.findById(anyLong()))
+			.willReturn(Optional.empty());
+
+
+		BaseException exception = assertThrows(BaseException.class,
+			() -> jwtService.reissue("refresh-token"));
+
+		assertEquals(BaseException.USER_NOT_FOUND, exception);
 	}
 }

--- a/src/test/java/com/devtraces/arterest/service/auth/OauthServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/auth/OauthServiceTest.java
@@ -66,8 +66,11 @@ class OauthServiceTest {
                 .build();
 
         TokenDto tokenDto = TokenDto.builder()
-                .accessToken("accessToken")
-                .cookie(
+                .accessTokenCookie(
+                    ResponseCookie.from("accessToken", "access-token")
+                        .build()
+                )
+                .refreshTokenCookie(
                         ResponseCookie.from("refreshToken", "refresh-token")
                                 .build()
                 )
@@ -124,11 +127,14 @@ class OauthServiceTest {
                 .build();
 
         TokenDto tokenDto = TokenDto.builder()
-                .accessToken("accessToken")
-                .cookie(
-                        ResponseCookie.from("refreshToken", "refresh-token")
-                                .build()
-                )
+            .accessTokenCookie(
+                ResponseCookie.from("accessToken", "access-token")
+                    .build()
+            )
+            .refreshTokenCookie(
+                ResponseCookie.from("refreshToken", "refresh-token")
+                    .build()
+            )
                 .build();
 
         given(userRepository.findByNickname(anyString()))
@@ -141,8 +147,8 @@ class OauthServiceTest {
                 oauthService.kakaoSignUpOrSignIn(dto);
 
         //then
-        assertEquals(tokenDto.getAccessToken(), response.getAccessToken());
-        assertEquals(tokenDto.getCookie(), response.getCookie());
+        assertEquals(tokenDto.getAccessTokenCookie().getValue(), response.getAcceesTokenCookie().getValue());
+        assertEquals(tokenDto.getRefreshTokenCookie().getValue(), response.getRefreshTokenCookie().getValue());
         assertEquals(user.getNickname(), response.getNickname());
     }
 

--- a/src/test/java/com/devtraces/arterest/service/like/LikeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/like/LikeServiceTest.java
@@ -192,7 +192,7 @@ class LikeServiceTest {
         given(userRepository.findAllByIdIn(userIdList)).willReturn(userEntityList);
 
         //when
-        List<LikeResponse> responseList = likeService.getLikedUserList(1L, 1L, 0, 10);
+        List<LikeResponse> responseList = likeService.getLikedUserList(1L, 0, 10);
 
         //then
         verify(feedRepository, times(1)).existsById(1L);
@@ -210,7 +210,7 @@ class LikeServiceTest {
         // when
         BaseException exception = assertThrows(
             BaseException.class ,
-            () -> likeService.getLikedUserList(1L, 1L, 0, 10)
+            () -> likeService.getLikedUserList(1L, 0, 10)
         );
 
         // then

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -65,7 +65,7 @@ class NoticeServiceTest {
 
         Notice notice = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
-                .sendUser(user)
+                .user(user)
                 .feed(feed)
                 .noticeType(noticeType)
                 .build();
@@ -79,7 +79,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(LIKE, captor.getValue().getNoticeType());
     }
@@ -100,7 +100,7 @@ class NoticeServiceTest {
 
         Notice notice = Notice.builder()
                 .noticeOwnerId(ownerUser.getId())
-                .sendUser(user)
+                .user(user)
                 .noticeType(noticeType)
                 .build();
         given(noticeRepository.save(any())).willReturn(notice);
@@ -113,7 +113,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(FOLLOW, captor.getValue().getNoticeType());
     }
 
@@ -139,7 +139,7 @@ class NoticeServiceTest {
 
         Notice notice = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
-                .sendUser(user)
+                .user(user)
                 .feed(feed)
                 .noticeType(noticeType)
                 .build();
@@ -153,7 +153,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(noticeOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(replyId, captor.getValue().getReply().getId());
         assertEquals(NoticeType.REPLY, captor.getValue().getNoticeType());
@@ -184,7 +184,7 @@ class NoticeServiceTest {
 
         Notice noticeForFeedOwner = Notice.builder()
                 .noticeOwnerId(feed.getUser().getId())
-                .sendUser(sendUser)
+                .user(sendUser)
                 .feed(feed)
                 .reply(reply)
                 .rereply(reReply)
@@ -202,7 +202,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(feedOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(replyId, captor.getValue().getReply().getId());
         assertEquals(POST, captor.getValue().getNoticeTarget());
@@ -234,7 +234,7 @@ class NoticeServiceTest {
 
         Notice noticeForReplyOwner = Notice.builder()
                 .noticeOwnerId(reply.getUser().getId())
-                .sendUser(sendUser)
+                .user(sendUser)
                 .feed(feed)
                 .reply(reply)
                 .rereply(reReply)
@@ -252,7 +252,7 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).save(captor.capture());
         assertEquals(replyOwnerId, captor.getValue().getNoticeOwnerId());
-        assertEquals(sendUserId, captor.getValue().getSendUser().getId());
+        assertEquals(sendUserId, captor.getValue().getUser().getId());
         assertEquals(feedId, captor.getValue().getFeed().getId());
         assertEquals(replyId, captor.getValue().getReply().getId());
         assertEquals(NoticeTarget.REPLY, captor.getValue().getNoticeTarget());

--- a/src/test/java/com/devtraces/arterest/service/user/AuthServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/user/AuthServiceTest.java
@@ -236,8 +236,8 @@ class AuthServiceTest {
 			.password("encodingPassword")
 			.build();
 		TokenDto mockTokenDto = TokenDto.builder()
-			.accessToken("access-token")
-			.cookie(ResponseCookie.from("refreshToken", "refresh-token").build())
+			.accessTokenCookie(ResponseCookie.from("accessToken", "access-token").build())
+			.refreshTokenCookie(ResponseCookie.from("refreshToken", "refresh-token").build())
 			.build();
 		given(userRepository.findByEmail(anyString()))
 			.willReturn(Optional.of(mockUser));


### PR DESCRIPTION
## 📍 관련 이슈
- 아직 만료되지 않은 Access Token 토큰에 대해서도 재발급이 가능하게 수정함.
- access token 도 refresh token 과 마찬가지로 쿠키에 담아서 발급함.

## 📍 특이사항
- access token 과 refresh token 를 각각 쿠키에 담아 전송함.
- api 들을 사용할때도 Authorization 헤더에 access token 을 입력할 필요 없이,
로그인 하면 자동으로 쿠키를 받게 되고, 해당 쿠키로 api 사용이 가능함 (포스트맨으로 테스트 할때 로그인하면 자동으로 쿠키를 받아놓게 됨).

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
