### PR TITLE
팔로우 추천 리스트 구현

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
+++ b/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
@@ -13,5 +13,10 @@ public class CommonConstant {
     public static final long REDIS_FOLLOW_SAMPLE_POOL_LIST_SIZE = 600L;
 
     public static final String REDIS_FOLLOW_RECOMMENDATION_LIST_KEY = "FollowRecommendationList";
-    
+
+    // 매 6 초마다.
+    public static final String PUSH_SAMPLE_TO_REDIS_CRON_STRING = "0/6 * * * * ?";
+
+    // 매 정각마다.
+    public static final String INITIALIZE_RECOMMENDATION_LIST_TO_REDIS_CONE_STRING = "0 0 0/1 * * *";
 }

--- a/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
+++ b/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
@@ -20,5 +20,5 @@ public class CommonConstant {
     public static final String PUSH_SAMPLE_TO_REDIS_CRON_STRING = "0/6 * * * * ?";
 
     // 매 정각마다.
-    public static final String INITIALIZE_RECOMMENDATION_LIST_TO_REDIS_CONE_STRING = "0 0 0/1 * * *";
+    public static final String INITIALIZE_RECOMMENDATION_LIST_TO_REDIS_CRON_STRING = "0 0 0/1 * * *";
 }

--- a/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
+++ b/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
@@ -14,6 +14,7 @@ public class CommonConstant {
 
     public static final String REDIS_FOLLOW_RECOMMENDATION_LIST_KEY = "FollowRecommendationList";
     public static final int FOLLOW_RECOMMENDATION_LIST_SIZE = 100;
+    public static final int FOLLOW_RECOMMENDATION_USER_NUMBER = 10;
 
     // 매 6 초마다.
     public static final String PUSH_SAMPLE_TO_REDIS_CRON_STRING = "0/6 * * * * ?";

--- a/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
+++ b/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
@@ -13,6 +13,7 @@ public class CommonConstant {
     public static final long REDIS_FOLLOW_SAMPLE_POOL_LIST_SIZE = 600L;
 
     public static final String REDIS_FOLLOW_RECOMMENDATION_LIST_KEY = "FollowRecommendationList";
+    public static final int FOLLOW_RECOMMENDATION_LIST_SIZE = 100;
 
     // 매 6 초마다.
     public static final String PUSH_SAMPLE_TO_REDIS_CRON_STRING = "0/6 * * * * ?";

--- a/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
+++ b/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
@@ -6,6 +6,12 @@ public class CommonConstant {
     public static final int FOLLOW_COUNT_LIMIT = 5000;
     public static final int HASHTAG_COUNT_LIMIT = 10;
     public static final int IMAGE_FILE_COUNT_LIMIT = 15;
+
     public static final String REDIS_LIKE_NUMBER_KEY_PREFIX = "LikeNumber:";
 
+    public static final String REDIS_FOLLOW_SAMPLE_POOL_LIST_KEY = "FollowSamplePoolList";
+    public static final long REDIS_FOLLOW_SAMPLE_POOL_LIST_SIZE = 600L;
+
+    public static final String REDIS_FOLLOW_RECOMMENDATION_LIST_KEY = "FollowRecommendationList";
+    
 }

--- a/src/main/java/com/devtraces/arterest/configuration/SchedulerConfiguration.java
+++ b/src/main/java/com/devtraces/arterest/configuration/SchedulerConfiguration.java
@@ -1,0 +1,20 @@
+package com.devtraces.arterest.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulerConfiguration implements SchedulingConfigurer {
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+
+        int n = Runtime.getRuntime().availableProcessors();
+        threadPoolTaskScheduler.setPoolSize(n);
+        threadPoolTaskScheduler.initialize();
+
+        taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
+    }
+}

--- a/src/main/java/com/devtraces/arterest/controller/follow/FollowController.java
+++ b/src/main/java/com/devtraces/arterest/controller/follow/FollowController.java
@@ -63,7 +63,7 @@ public class FollowController {
     public ApiSuccessResponse<List<FollowResponse>> getFollowSuggestionList(
         @AuthenticationPrincipal Long userId
     ){
-        return followService.getRecommendationList();
+        return ApiSuccessResponse.from(followService.getRecommendationList());
     }
 
 }

--- a/src/main/java/com/devtraces/arterest/controller/follow/FollowController.java
+++ b/src/main/java/com/devtraces/arterest/controller/follow/FollowController.java
@@ -60,9 +60,7 @@ public class FollowController {
     }
 
     @GetMapping("/suggestion")
-    public ApiSuccessResponse<List<FollowResponse>> getFollowSuggestionList(
-        @AuthenticationPrincipal Long userId
-    ){
+    public ApiSuccessResponse<List<FollowResponse>> getFollowSuggestionList(){
         return ApiSuccessResponse.from(followService.getRecommendationList());
     }
 

--- a/src/main/java/com/devtraces/arterest/controller/follow/FollowController.java
+++ b/src/main/java/com/devtraces/arterest/controller/follow/FollowController.java
@@ -59,4 +59,11 @@ public class FollowController {
         return ApiSuccessResponse.NO_DATA_RESPONSE;
     }
 
+    @GetMapping("/suggestion")
+    public ApiSuccessResponse<List<FollowResponse>> getFollowSuggestionList(
+        @AuthenticationPrincipal Long userId
+    ){
+        return followService.getRecommendationList();
+    }
+
 }

--- a/src/main/java/com/devtraces/arterest/model/follow/FollowRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/follow/FollowRepository.java
@@ -1,5 +1,6 @@
 package com.devtraces.arterest.model.follow;
 
+import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,4 +25,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     int isFollowing(Long userId, Long followingId);
     
     boolean existsByUserIdAndFollowingId(Long user_id, Long followingId);
+
+    Optional<Follow> findTopByOrderByIdDesc();
 }

--- a/src/main/java/com/devtraces/arterest/model/followcache/FollowRecommendCacheRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/followcache/FollowRecommendCacheRepository.java
@@ -1,0 +1,51 @@
+package com.devtraces.arterest.model.followcache;
+
+import com.devtraces.arterest.common.constant.CommonConstant;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class FollowRecommendCacheRepository {
+
+    private final RedisTemplate<String, String> template;
+    private final String key = CommonConstant.REDIS_FOLLOW_RECOMMENDATION_LIST_KEY;
+
+    // DB로부터 특정 유저가 팔로우한 사람들의 주키 아이디 값 리스트를 받아서 레디스에 저장한다.
+    public void setRecommendationTargetUserIdList(List<Long> recommendationList) {
+        try {
+            template.delete(key);
+            for(Long id : recommendationList){
+                template.opsForList().rightPush(key, String.valueOf(id));
+            }
+        } catch (Exception e) {
+            log.error("팔로우 추천 타깃 유저 리스트 캐시 실패.");
+        }
+    }
+
+    // 팔로우 추천 타깃 유저 리스트를 리턴한다.
+    public List<Long> getFollowTargetUserIdList(){
+        try {
+            return getLongs(template, key);
+        } catch (Exception e){
+            log.error("레디스로부터 팔로우 추천 타깃 유저 리스트 획득 실패");
+            return null;
+        }
+    }
+    static List<Long> getLongs(RedisTemplate<String, String> template, String key) {
+        Long size = template.opsForList().size(key);
+        if(size != null){
+            List<String> listFromRedis = template.opsForList().range(key, 0, size);
+            assert listFromRedis != null;
+            return listFromRedis.stream().map(Long::valueOf).collect(Collectors.toList());
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/com/devtraces/arterest/model/followcache/FollowRecommendationCacheRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/followcache/FollowRecommendationCacheRepository.java
@@ -11,13 +11,13 @@ import org.springframework.stereotype.Repository;
 @Slf4j
 @Repository
 @RequiredArgsConstructor
-public class FollowRecommendCacheRepository {
+public class FollowRecommendationCacheRepository {
 
     private final RedisTemplate<String, String> template;
     private final String key = CommonConstant.REDIS_FOLLOW_RECOMMENDATION_LIST_KEY;
 
     // DB로부터 특정 유저가 팔로우한 사람들의 주키 아이디 값 리스트를 받아서 레디스에 저장한다.
-    public void setRecommendationTargetUserIdList(List<Long> recommendationList) {
+    public void updateRecommendationTargetUserIdList(List<Long> recommendationList) {
         try {
             template.delete(key);
             for(Long id : recommendationList){

--- a/src/main/java/com/devtraces/arterest/model/followcache/FollowSamplePoolCacheRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/followcache/FollowSamplePoolCacheRepository.java
@@ -1,0 +1,50 @@
+package com.devtraces.arterest.model.followcache;
+
+import com.devtraces.arterest.common.constant.CommonConstant;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class FollowSamplePoolCacheRepository {
+
+    private final RedisTemplate<String, String> template;
+    private final String key = CommonConstant.REDIS_FOLLOW_SAMPLE_POOL_LIST_KEY;
+
+    // 새로운 팔로우 정보 표본을 저장한다.
+    // 리스트의 길이를 600개 이내로 유지한다.
+    public void pushSample(Long followTargetUserId) {
+        try {
+            template.opsForList().rightPush(key, String.valueOf(followTargetUserId));
+            Long size = template.opsForList().size(key);
+            if(size != null && size > CommonConstant.REDIS_FOLLOW_SAMPLE_POOL_LIST_SIZE){
+                template.opsForList().leftPop(key);
+            }
+        } catch (Exception e) {
+            log.error("팔로우 샘플 레디스 리스트에 푸시 실패");
+        }
+    }
+
+    // 레디스에 저장돼 있는 리스트를 반환한다.
+    public List<Long> getSampleList(){
+        try {
+            Long size = template.opsForList().size(key);
+            if(size != null){
+                List<String> listFromRedis = template.opsForList().range(key, 0, size);
+                assert listFromRedis != null;
+                return listFromRedis.stream().map(Long::valueOf).collect(Collectors.toList());
+            } else {
+                return null;
+            }
+        } catch (Exception e){
+            log.error("레디스로부터 팔로우 샘플 리스트 획득 실패");
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/com/devtraces/arterest/model/followcache/FollowSamplePoolCacheRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/followcache/FollowSamplePoolCacheRepository.java
@@ -1,6 +1,6 @@
 package com.devtraces.arterest.model.followcache;
 
-import static com.devtraces.arterest.model.followcache.FollowRecommendCacheRepository.getLongs;
+import static com.devtraces.arterest.model.followcache.FollowRecommendationCacheRepository.getLongs;
 
 import com.devtraces.arterest.common.constant.CommonConstant;
 import java.util.List;

--- a/src/main/java/com/devtraces/arterest/model/followcache/FollowSamplePoolCacheRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/followcache/FollowSamplePoolCacheRepository.java
@@ -1,8 +1,9 @@
 package com.devtraces.arterest.model.followcache;
 
+import static com.devtraces.arterest.model.followcache.FollowRecommendCacheRepository.getLongs;
+
 import com.devtraces.arterest.common.constant.CommonConstant;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -33,14 +34,7 @@ public class FollowSamplePoolCacheRepository {
     // 레디스에 저장돼 있는 리스트를 반환한다.
     public List<Long> getSampleList(){
         try {
-            Long size = template.opsForList().size(key);
-            if(size != null){
-                List<String> listFromRedis = template.opsForList().range(key, 0, size);
-                assert listFromRedis != null;
-                return listFromRedis.stream().map(Long::valueOf).collect(Collectors.toList());
-            } else {
-                return null;
-            }
+            return getLongs(template, key);
         } catch (Exception e){
             log.error("레디스로부터 팔로우 샘플 리스트 획득 실패");
             return null;

--- a/src/main/java/com/devtraces/arterest/model/recommendation/FollowRecommendation.java
+++ b/src/main/java/com/devtraces/arterest/model/recommendation/FollowRecommendation.java
@@ -1,0 +1,30 @@
+package com.devtraces.arterest.model.recommendation;
+
+import com.devtraces.arterest.common.model.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class FollowRecommendation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 1200)
+    private String followRecommendationTargetUsers;
+}

--- a/src/main/java/com/devtraces/arterest/model/recommendation/FollowRecommendationRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/recommendation/FollowRecommendationRepository.java
@@ -1,0 +1,12 @@
+package com.devtraces.arterest.model.recommendation;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FollowRecommendationRepository extends JpaRepository<FollowRecommendation,Long> {
+
+    Optional<FollowRecommendation> findTopByOrderByIdDesc();
+
+}

--- a/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
+++ b/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
@@ -170,9 +170,14 @@ public class FollowService {
             followRecommendationCacheRepository.updateRecommendationTargetUserIdList(recommendationList);
 
             // 캐시서버가 다운되었을 경우를 대비하여 DB에도 별도의 새로운 테이블을 만들어서 저장해 둔다.
+            StringBuilder builder = new StringBuilder();
+            for(Long id : recommendationList){
+                builder.append(id);
+                builder.append(",");
+            }
             followRecommendationRepository.save(
                 FollowRecommendation.builder()
-                    .followRecommendationTargetUsers(recommendationList.toString())
+                    .followRecommendationTargetUsers(builder.toString())
                     .build()
             );
         }
@@ -197,7 +202,6 @@ public class FollowService {
             }
         }
         // 리스트를 랜덤으로 섞은 후, 상위 10개(recommendedUserIdList의 길이가 10 미만이면 그 만큼)를 뽑아낸다.
-        assert recommendedUserIdList != null;
         Collections.shuffle(recommendedUserIdList);
         List<Long> resultIdList = new ArrayList<>();
         for(Long id : recommendedUserIdList){

--- a/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
+++ b/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
@@ -2,7 +2,6 @@ package com.devtraces.arterest.service.follow;
 
 import com.devtraces.arterest.common.constant.CommonConstant;
 import com.devtraces.arterest.common.exception.BaseException;
-import com.devtraces.arterest.common.response.ApiSuccessResponse;
 import com.devtraces.arterest.controller.follow.dto.response.FollowResponse;
 import com.devtraces.arterest.model.follow.Follow;
 import com.devtraces.arterest.model.follow.FollowRepository;
@@ -15,7 +14,6 @@ import com.devtraces.arterest.model.user.UserRepository;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -146,8 +144,7 @@ public class FollowService {
     // 매 정각마다 followSamplePoolCacheRepository를 통해 레디스에 저장된
     // 팔로우 추천 대상 유저 선별용 샘플 리스트의 내용을 바탕으로
     // 최근 1시간 이내에 팔로우를 많이 받은 상위 일정 수 만큼의 유저들의 주키 아이디 값 리스트를 캐시해 둔다.
-    // 캐시서버가 다운되었을 경우를 대비하여 DB에도 별도의 새로운 테이블을 만들어서 저장해 둔다.
-    @Scheduled(cron = CommonConstant.INITIALIZE_RECOMMENDATION_LIST_TO_REDIS_CONE_STRING)
+    @Scheduled(cron = CommonConstant.INITIALIZE_RECOMMENDATION_LIST_TO_REDIS_CRON_STRING)
     public void initializeFollowRecommendationTargetUserIdListToCacheServer(){
         List<Long> sampleList = followSamplePoolCacheRepository.getSampleList();
         if(sampleList != null){
@@ -172,6 +169,7 @@ public class FollowService {
 
             followRecommendationCacheRepository.updateRecommendationTargetUserIdList(recommendationList);
 
+            // 캐시서버가 다운되었을 경우를 대비하여 DB에도 별도의 새로운 테이블을 만들어서 저장해 둔다.
             followRecommendationRepository.save(
                 FollowRecommendation.builder()
                     .followRecommendationTargetUsers(recommendationList.toString())
@@ -198,7 +196,7 @@ public class FollowService {
                 return Collections.emptyList();
             }
         }
-        // 리스트를 랜덤으로 섞은 후, 상위 10개(recommendedUserIdList의 길이가 10미만일 경우 그 이하)를 뽑아낸다.
+        // 리스트를 랜덤으로 섞은 후, 상위 10개(recommendedUserIdList의 길이가 10 미만이면 그 만큼)를 뽑아낸다.
         assert recommendedUserIdList != null;
         Collections.shuffle(recommendedUserIdList);
         List<Long> resultIdList = new ArrayList<>();

--- a/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
+++ b/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -142,23 +143,23 @@ public class FollowService {
     // 매 정각마다 followSamplePoolCacheRepository를 통해 레디스에 저장된
     // 팔로우 추천 대상 유저 선별용 샘플 리스트의 내용을 바탕으로
     // 최근 1시간 이내에 팔로우를 많이 받은 상위 일정 수 만큼의 유저들의 주키 아이디 값 리스트를 캐시해 둔다.
-    // 캐시서버가 다운되었을 경우를 대비하여 DB에도 저장해 둔다.
+    // 캐시서버가 다운되었을 경우를 대비하여 DB에도 별도의 새로운 테이블을 만들어서 저장해 둔다.
     @Scheduled(cron = CommonConstant.INITIALIZE_RECOMMENDATION_LIST_TO_REDIS_CONE_STRING)
     public void initializeFollowRecommendationTargetUserIdListToCacheServer(){
         List<Long> sampleList = followSamplePoolCacheRepository.getSampleList();
         if(sampleList != null){
-            Map<Long, Integer> userIdToCountMap = new HashMap<>();
-            for(long id : sampleList){
-                userIdToCountMap.put(id, userIdToCountMap.getOrDefault(id, 0)+1);
-            }
+            // 주키 아이디 : 팔로우 받은 횟수 카운트 맵 구성.
+            Map<Long, Integer> userIdToCountMap = sampleList.stream().collect(
+                Collectors.toMap(Function.identity(), e -> 1, Math::addExact)
+            );
 
+            // 맵 내용물 중에서 카운트 높은 횟수 100개 (100개 보다 적다면 중간에 브레이크) 골라내기.
             PriorityQueue<Map.Entry<Long, Integer>> priorityQueue = new PriorityQueue<>(
                 (x,y) -> (y.getValue() - x.getValue())
             );
             for(Map.Entry<Long, Integer> entry : userIdToCountMap.entrySet()){
                 priorityQueue.offer(entry);
             }
-
             List<Long> recommendationList = new ArrayList<>();
             for(int i=1; i<= CommonConstant.FOLLOW_RECOMMENDATION_LIST_SIZE; i++){
                 if(!priorityQueue.isEmpty()){

--- a/src/test/http/test.http
+++ b/src/test/http/test.http
@@ -78,8 +78,11 @@ Content-Type: application/json
 DELETE http://localhost:8080/api/feeds/1/replies/1/rereplies/1/1
 
 
+
 ### 테스트 유저 생성 & 초기 작업 진행.
 POST http://localhost:8080/make-testuser
+
+
 
 ### 팔로우 관계 설정 / 1>2 - OK
 POST http://localhost:8080/api/follows/two?userId=1
@@ -145,3 +148,7 @@ GET http://localhost:8080/api/feeds/1?userId=6
 
 ### 피드 리스트로 읽기 - 좋아요 개수 잘 들어오나? - OK
 GET http://localhost:8080/api/feeds/list/six?userId=6&page=0
+
+
+### 팔로우 추천 리스트 읽기
+GET http://localhost:8080/api/follows/suggestion


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #107 

## 📍 특이사항
- 최근 1시간 동안에 가장 팔로우를 많이 받은 유저 100명(혹은 그 이하)를 추려낸 다음, 그 중에서 랜덤으로 10명(혹은 그 이하)를 골라서 팔로우 추천 리스트로 리턴해야 함.
- 다수의 스케쥴드 메서드들의 정상  작동을 위해서 SchedulerConfiguration 빈을 설정함. 이를 설정해주지 않을 경우, 1개 스레드가 Scheduled 어노테이션이 붙어 있는 다수의 메서드를 처리하면서 시간 간격 동작이 비정상적으로 작동하게 됨.
- 최근 1시간 동안의 모든 팔로우를 전수조사하는 것은 불가능하므로, 매 6초 간격으로 팔로우 테이블에서 가장 마지막 요소를 레디스에 샘플 리스트로 저장함.
- 매 시 정각(1:00 시, 2:00시 ...)마다 레디스에 저장된 샘플 리스트(최대 길이 600)를 불러와서 이 중에서 가장 많은 팔로우를 받은 유저 100명(혹은 그 이하)을 골라내서 레디스와 DB(follow_recommendation이라는 새로운 테이블 생성했음)에 저장함.
- 팔로우 추천 리스트를 호출할 때는 바로 위에서 저장해 놓은 레디스 리스트를 보거나, 레디스가 접근 불가능할 경우 DB의 follow_fecommendation 테이블의 가장 마지막 레코드를 읽어서 그 중에서 랜덤으로 10명을 골라서 FE에 리턴하면 됨.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트