### PR TITLE
특정 게시물에 좋아요 누른 유저 리스트 API 리팩토링

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/follow/dto/response/FollowResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/follow/dto/response/FollowResponse.java
@@ -36,8 +36,7 @@ public class FollowResponse {
 				.nickname(user.getNickname())
 				.description(user.getDescription())
 				.isFollowing(
-					followingUserIdSet == null ? false :
-					followingUserIdSet.contains(user.getId())
+					followingUserIdSet != null && followingUserIdSet.contains(user.getId())
 					)
 				.build();
 		}

--- a/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/LikeController.java
@@ -41,12 +41,13 @@ public class LikeController {
 
     @GetMapping("/feeds/like/{feedId}")
     public ApiSuccessResponse<List<LikeResponse>> getLikedUserList(
+        @AuthenticationPrincipal Long userId,
         @PathVariable Long feedId,
         @RequestParam int page,
         @RequestParam(required = false, defaultValue = "10") int pageSize
     ){
         return ApiSuccessResponse.from(
-            likeService.getLikedUserList(feedId, page, pageSize)
+            likeService.getLikedUserList(userId, feedId, page, pageSize)
         );
     }
 

--- a/src/main/java/com/devtraces/arterest/controller/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/dto/response/LikeResponse.java
@@ -4,6 +4,7 @@ import com.devtraces.arterest.common.type.UserSignUpType;
 import com.devtraces.arterest.model.like.Likes;
 import com.devtraces.arterest.model.user.User;
 import java.time.LocalDateTime;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,11 +24,14 @@ public class LikeResponse {
     private String nickname;
     private boolean isFollowing;
 
-    public static LikeResponse from(User user){
+    public static LikeResponse from(User user, Set<Long> likedUserIdSet){
         return LikeResponse.builder()
             .profileImageUrl(user.getProfileImageUrl())
             .userName(user.getUsername())
             .nickname(user.getNickname())
+            .isFollowing(
+                likedUserIdSet != null && likedUserIdSet.contains(user.getId())
+            )
             .build();
     }
 

--- a/src/main/java/com/devtraces/arterest/controller/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/dto/response/LikeResponse.java
@@ -18,14 +18,14 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LikeResponse {
 
-    private String profileImageLink;
+    private String profileImageUrl;
     private String userName;
     private String nickname;
     private boolean isFollowing;
 
     public static LikeResponse from(User user){
         return LikeResponse.builder()
-            .profileImageLink(user.getProfileImageUrl())
+            .profileImageUrl(user.getProfileImageUrl())
             .userName(user.getUsername())
             .nickname(user.getNickname())
             .build();

--- a/src/main/java/com/devtraces/arterest/controller/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/like/dto/response/LikeResponse.java
@@ -18,25 +18,16 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LikeResponse {
 
-    private Long userId;
     private String profileImageLink;
     private String userName;
     private String nickname;
-    private String description;
-    private LocalDateTime createdAt;
-    private LocalDateTime modifiedAt;
-    private UserSignUpType signupType;
+    private boolean isFollowing;
 
     public static LikeResponse from(User user){
         return LikeResponse.builder()
-            .userId(user.getId())
             .profileImageLink(user.getProfileImageUrl())
             .userName(user.getUsername())
             .nickname(user.getNickname())
-            .description(user.getDescription())
-            .createdAt(user.getCreatedAt())
-            .modifiedAt(user.getModifiedAt())
-            .signupType(user.getSignupType())
             .build();
     }
 

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -55,7 +55,7 @@ public class LikeService {
 
     @Transactional(readOnly = true)
     public List<LikeResponse> getLikedUserList(
-        Long feedId, int page, int pageSize
+        Long userId, Long feedId, int page, int pageSize
     ) {
         validateFeedExistence(feedId);
         PageRequest pageRequest = PageRequest.of(page, pageSize);

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -61,14 +61,15 @@ public class LikeService {
         Long userId, Long feedId, int page, int pageSize
     ) {
         validateFeedExistence(feedId);
-        PageRequest pageRequest = PageRequest.of(page, pageSize);
-        List<Long> likedUserIdList = likeRepository
-            .findAllByFeedIdOrderByCreatedAtDesc(feedId, pageRequest)
-            .getContent().stream().map(Likes::getUserId).collect(Collectors.toList());
 
         User requestedUser = userRepository.findById(userId).orElseThrow(
             () -> BaseException.USER_NOT_FOUND
         );
+
+        PageRequest pageRequest = PageRequest.of(page, pageSize);
+        List<Long> likedUserIdList = likeRepository
+            .findAllByFeedIdOrderByCreatedAtDesc(feedId, pageRequest)
+            .getContent().stream().map(Likes::getUserId).collect(Collectors.toList());
 
         Set<Long> followingUserIdSetOfRequestUser = requestedUser.getFollowList()
             .stream().map(Follow::getFollowingId).collect(Collectors.toSet());

--- a/src/main/java/com/devtraces/arterest/service/like/LikeService.java
+++ b/src/main/java/com/devtraces/arterest/service/like/LikeService.java
@@ -3,12 +3,15 @@ package com.devtraces.arterest.service.like;
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.controller.like.dto.response.LikeResponse;
 import com.devtraces.arterest.model.feed.FeedRepository;
+import com.devtraces.arterest.model.follow.Follow;
 import com.devtraces.arterest.model.like.LikeRepository;
 import com.devtraces.arterest.model.like.Likes;
 import com.devtraces.arterest.model.likecache.LikeNumberCacheRepository;
+import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -63,8 +66,17 @@ public class LikeService {
             .findAllByFeedIdOrderByCreatedAtDesc(feedId, pageRequest)
             .getContent().stream().map(Likes::getUserId).collect(Collectors.toList());
 
+        User requestedUser = userRepository.findById(userId).orElseThrow(
+            () -> BaseException.USER_NOT_FOUND
+        );
+
+        Set<Long> followingUserIdSetOfRequestUser = requestedUser.getFollowList()
+            .stream().map(Follow::getFollowingId).collect(Collectors.toSet());
+
         return userRepository.findAllByIdIn(likedUserIdList).stream()
-            .map(LikeResponse::from).collect(Collectors.toList());
+            .map(
+                user -> LikeResponse.from(user, followingUserIdSetOfRequestUser)
+            ).collect(Collectors.toList());
     }
 
     @Transactional


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #118 

## 📍 특이사항
- FE에서 특정 게시물에 좋아요 누른 유저 리스트 획득 API에 대해 불필요한 응답 필드의 제거와, 팔로잉 여부 확인을 위한 boolean isFollowing 필드 추가를 요청함.
- 이를 반영하여 리팩토링을 진행함.
- 좋아요 누른 유저 리스트를 요청한 유저가 팔로우 하고 있는 다른 유저들의 리스트를 가져오기 위해서 AuthenticationPricipal  Long userId 파라미터를 다시 추가하여 컨트롤러 및 서비스 메서드에서 활용함.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
