### PR TITLE
회원탈퇴 API 구현

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
@@ -4,6 +4,7 @@ import static com.devtraces.arterest.common.jwt.JwtProperties.TOKEN_PREFIX;
 
 import com.devtraces.arterest.common.response.ApiSuccessResponse;
 import com.devtraces.arterest.controller.auth.dto.TokenWithNicknameDto;
+import com.devtraces.arterest.controller.auth.dto.request.DeleteUserRequest;
 import com.devtraces.arterest.controller.auth.dto.request.MailAuthKeyCheckRequest;
 import com.devtraces.arterest.controller.auth.dto.request.MailAuthKeyRequest;
 import com.devtraces.arterest.controller.auth.dto.request.SignInRequest;
@@ -96,5 +97,14 @@ public class AuthController {
 	public ApiSuccessResponse<PasswordCheckResponse> checkPassword(@AuthenticationPrincipal long userId, @RequestBody @Valid PasswordCheckRequest request) {
 		boolean isCorrect = authService.checkPassword(userId, request.getPassword());
 		return ApiSuccessResponse.from(PasswordCheckResponse.builder().isCorrect(isCorrect).build());
+	}
+
+	@PostMapping("/withdrawal")
+	public ApiSuccessResponse<?> deleteUser(
+		@AuthenticationPrincipal long userId,
+		@RequestBody @Valid DeleteUserRequest request
+	) {
+		authService.deleteUser(userId, request.getPassword());
+		return ApiSuccessResponse.NO_DATA_RESPONSE;
 	}
 }

--- a/src/main/java/com/devtraces/arterest/controller/auth/dto/request/DeleteUserRequest.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/dto/request/DeleteUserRequest.java
@@ -1,0 +1,13 @@
+package com.devtraces.arterest.controller.auth.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeleteUserRequest {
+	private String password;
+}

--- a/src/main/java/com/devtraces/arterest/model/follow/FollowRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/follow/FollowRepository.java
@@ -1,5 +1,6 @@
 package com.devtraces.arterest.model.follow;
 
+import com.devtraces.arterest.model.user.User;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,4 +25,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     int isFollowing(Long userId, Long followingId);
     
     boolean existsByUserIdAndFollowingId(Long user_id, Long followingId);
+
+    void deleteAllByFollowingId(Long followingId);
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
@@ -1,5 +1,6 @@
 package com.devtraces.arterest.model.notice;
 
+import com.devtraces.arterest.model.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,8 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Integer countAllByNoticeOwnerId(Long noticeOwnerId);
 
     Page<Notice> findALlByNoticeOwnerId(Long noticeOwnerId, PageRequest pageRequest);
+
+    void deleteAllByNoticeOwnerId(Long noticeOwnerId);
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/devtraces/arterest/service/auth/AuthService.java
+++ b/src/main/java/com/devtraces/arterest/service/auth/AuthService.java
@@ -2,8 +2,15 @@ package com.devtraces.arterest.service.auth;
 
 import com.devtraces.arterest.common.type.UserSignUpType;
 import com.devtraces.arterest.common.type.UserStatusType;
+import com.devtraces.arterest.controller.auth.dto.request.DeleteUserRequest;
+import com.devtraces.arterest.model.feed.Feed;
+import com.devtraces.arterest.model.follow.Follow;
+import com.devtraces.arterest.model.follow.FollowRepository;
+import com.devtraces.arterest.model.notice.NoticeRepository;
 import com.devtraces.arterest.service.auth.util.AuthRedisUtil;
 import com.devtraces.arterest.service.auth.util.TokenRedisUtil;
+import com.devtraces.arterest.service.feed.application.FeedDeleteApplication;
+import com.devtraces.arterest.service.follow.FollowService;
 import com.devtraces.arterest.service.s3.S3Service;
 import com.devtraces.arterest.service.mail.MailService;
 import com.devtraces.arterest.common.exception.BaseException;
@@ -40,6 +47,9 @@ public class AuthService {
 	private final AuthRedisUtil authRedisUtil;
 	private final TokenRedisUtil tokenRedisUtil;
 	private final UserRepository userRepository;
+	private final FeedDeleteApplication feedDeleteApplication;
+	private final FollowRepository followRepository;
+	private final NoticeRepository noticeRepository;
 
 	@Transactional
 	public UserRegistrationResponse register(
@@ -153,5 +163,30 @@ public class AuthService {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> BaseException.USER_NOT_FOUND);
 		return passwordEncoder.matches(password, user.getPassword());
+	}
+
+	@Transactional
+	public void deleteUser(long userId, String password) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> BaseException.USER_NOT_FOUND);
+		if (!passwordEncoder.matches(password, user.getPassword())) {
+			throw BaseException.WRONG_EMAIL_OR_PASSWORD;
+		}
+
+		//알림 삭제
+		noticeRepository.deleteAllByNoticeOwnerId(userId);
+		noticeRepository.deleteAllByUser(user);
+
+		//팔로우 삭제
+		followRepository.deleteAllByFollowingId(userId);
+		followRepository.deleteAllByUser(user);
+
+		//게시물, 댓글, 대댓글, 좋아요, 북마크, 해시태그 삭제
+		for(Feed feed : user.getFeedList()){
+			feedDeleteApplication.deleteFeed(userId, feed.getId());
+		}
+
+		//유저 삭제
+		userRepository.deleteById(user.getId());
 	}
 }


### PR DESCRIPTION
## 📍 관련 이슈
- 회원 탈퇴 API 구현 및 테스트코드 작성

## 📍 특이사항
- 회원 탈퇴시, 해당 유저에 관련된 게시물, 댓글, 대댓글, 좋아요, 알림, 팔로우, 북마크, 해시태그 정보를 모두 DB 에서 삭제하는 방향으로 구현함.
- 해시태그, 좋아요, 북마크, 대댓글, 댓글, 게시물의 경우 게시물 FeedDeleteApplication 클래스에 게시물 삭제 api 를 호출하여 삭제함.
- 알림, 팔로우, 유저의 경우 직접 DB 에 접근하여 삭제함.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
