### PR TITLE
공란으로 이름 및 닉네임 검색시 빈배열 리턴

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
@@ -85,8 +85,8 @@ public class JwtProvider {
 			.httpOnly(true)
 			.path("/")
 			.maxAge(CREATE_AGE)
-			.secure(true)
-			.sameSite(SameSite.NONE.attributeValue())
+//			.secure(true)
+//			.sameSite(SameSite.NONE.attributeValue())
 			.build();
 
 		return cookie;

--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
@@ -85,8 +85,8 @@ public class JwtProvider {
 			.httpOnly(true)
 			.path("/")
 			.maxAge(CREATE_AGE)
-//			.secure(true)
-//			.sameSite(SameSite.NONE.attributeValue())
+			.secure(true)
+			.sameSite(SameSite.NONE.attributeValue())
 			.build();
 
 		return cookie;

--- a/src/main/java/com/devtraces/arterest/service/search/SearchService.java
+++ b/src/main/java/com/devtraces/arterest/service/search/SearchService.java
@@ -13,6 +13,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -70,6 +71,8 @@ public class SearchService {
 		String keyword, Integer page, Integer pageSize) {
 		Pageable pageable = PageRequest.of(page, pageSize);
 
+		if("".equals(keyword)) return new ArrayList<>();
+
 		return userRepository.findByUsernameStartsWith(keyword, pageable)
 			.stream().map(User -> GetUsernameSearchResponse.from(User))
 			.collect(Collectors.toList());
@@ -78,6 +81,8 @@ public class SearchService {
 	public List<GetNicknameSearchResponse> getSearchResultUsingNickname(
 		String keyword, Integer page, Integer pageSize) {
 		Pageable pageable = PageRequest.of(page, pageSize);
+
+		if("".equals(keyword)) return new ArrayList<>();
 
 		return userRepository.findByNicknameStartsWith(keyword, pageable)
 			.stream().map(User -> GetNicknameSearchResponse.from(User))


### PR DESCRIPTION
## 📍 관련 이슈
- 기존에 공란으로 이름 및 닉네임 검색시, 모든 사용자 정보가 리턴되는 문제를 빈배열만 리턴하게 수정함.

## 📍 특이사항

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
