### PR TITLE
카카오 소셜로그인 후 받은 토큰이 유요하지 않은 문제 해결

### DIFF
--- a/src/main/java/com/devtraces/arterest/service/auth/OauthService.java
+++ b/src/main/java/com/devtraces/arterest/service/auth/OauthService.java
@@ -17,6 +17,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -25,6 +26,7 @@ public class OauthService {
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public TokenWithNicknameDto oauthKakaoSignIn(String accessTokenFromKakao) {
         // kakao 서버에 액세스 토큰 보낸 뒤 사용자 정보 가져오기
@@ -151,6 +153,7 @@ public class OauthService {
         User savedUser = userRepository.save(User.builder()
                 .kakaoUserId(kakaoUserId)
                 .email(userInfoFromKakaoDto.getEmail())
+                .password(passwordEncoder.encode(userInfoFromKakaoDto.getNickname()))
                 .username(userInfoFromKakaoDto.getUsername())
                 .nickname(userInfoFromKakaoDto.getNickname())
                 .profileImageUrl(userInfoFromKakaoDto.getProfileImageUrl())

--- a/src/test/java/com/devtraces/arterest/service/auth/OauthServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/auth/OauthServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseCookie;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -37,6 +38,9 @@ class OauthServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
     @InjectMocks
     private OauthService oauthService;
 
@@ -53,10 +57,12 @@ class OauthServiceTest {
                 .description("description")
                 .build();
 
+        String encodedPassword = "encodedPassword";
         User user = User.builder()
                 .id(1L)
                 .kakaoUserId(dto.getKakaoUserId())
                 .email(dto.getEmail())
+                .password(encodedPassword)
                 .username(dto.getUsername())
                 .nickname(dto.getNickname())
                 .profileImageUrl(dto.getProfileImageUrl())
@@ -80,6 +86,7 @@ class OauthServiceTest {
                 .willReturn(Optional.empty());
         given(userRepository.findByKakaoUserId(anyLong()))
                 .willReturn(Optional.empty());
+        given(passwordEncoder.encode(anyString())).willReturn(encodedPassword);
         given(userRepository.save(any())).willReturn(user);
         given(jwtProvider.generateAccessTokenAndRefreshToken(user.getId()))
                 .willReturn(tokenDto);
@@ -114,10 +121,12 @@ class OauthServiceTest {
                 .description("description")
                 .build();
 
+        String encodedPassword = "encodedPassword";
         User user = User.builder()
                 .id(1L)
                 .kakaoUserId(dto.getKakaoUserId())
                 .email(dto.getEmail())
+                .password(encodedPassword)
                 .username(dto.getUsername())
                 .nickname(dto.getNickname())
                 .profileImageUrl(dto.getProfileImageUrl())


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #127 

## 📍 특이사항
* 카카오 소셜로그인 성공 후 받은 액세스 토큰이 정상 작동하지 않고, 401 에러를 발생시키는 문제가 발생했습니다.
* 사용자의 비밀번호를 설정해주지 않아 발생한 문제로, 최초 소셜 로그인 시 사용자 정보에 임의의 비밀번호를 부여해주었습니다. 
* 소셜 로그인 사용자가 비밀번호에 접근할 수 없기 때문에 임의로 설정했습니다.

## 📍 테스트
- [ ] API Test
- [ ] 단위 테스트
