### PR TITLE
카카오 로그인시 랜덤 닉네임 변경

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
+++ b/src/main/java/com/devtraces/arterest/common/constant/CommonConstant.java
@@ -1,5 +1,9 @@
 package com.devtraces.arterest.common.constant;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class CommonConstant {
 
     public static final int CONTENT_LENGTH_LIMIT = 1000;
@@ -29,4 +33,9 @@ public class CommonConstant {
 
     // 매 정각마다.
     public static final String INITIALIZE_RECOMMENDATION_LIST_TO_REDIS_CRON_STRING = "0 0 0/1 * * *";
+
+    public static final List<String> ARTIST_NAME_LIST = new ArrayList<>(
+        Arrays.asList("LeonardoDaVinci", "VincentVanGogh", "PabloPicasso", "ClaudeMonet",
+            "JohannesVermeer", "EdvardMunch", "SalvadorDali", "AndyWarhol", "HenriMatisse",
+            "NamJunePaik"));
 }

--- a/src/main/java/com/devtraces/arterest/service/auth/OauthService.java
+++ b/src/main/java/com/devtraces/arterest/service/auth/OauthService.java
@@ -1,5 +1,7 @@
 package com.devtraces.arterest.service.auth;
 
+import static com.devtraces.arterest.common.constant.CommonConstant.ARTIST_NAME_LIST;
+
 import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.jwt.JwtProvider;
 import com.devtraces.arterest.common.type.UserSignUpType;
@@ -141,9 +143,8 @@ public class OauthService {
     private String generateRandomNickname() {
         String randomNickname = "";
         do {
-            for (int i = 0; i < 30; i++) {
-                randomNickname += (char) ((int) (Math.random() * 25) + 97);
-            }
+            randomNickname = ARTIST_NAME_LIST.get((int) (Math.random() * 10)) + "_"
+                + (int) (Math.random() * 10000000);
         } while (userRepository.existsByNickname(randomNickname));
 
         return randomNickname;


### PR DESCRIPTION
## 📍 관련 이슈
- 카카오 로그인시 랜덤으로 설정되는 닉네임이 닉네임 검색에 나타나므로, 좀 더 읽고 보기에 좋은 랜덤 닉네임으로 설정함.

## 📍 특이사항
- 카카오 로그인시 닉네임을 (랜덤 유명 화가명 + 랜덤 숫자)로 설정

## 📍 테스트
- [x] API Test
