### PR TITLE
팔로우 취소할 때 관련 팔로우 알림 삭제 기능 추가 

### DIFF
--- a/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
@@ -16,4 +16,6 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     void deleteAllByNoticeOwnerId(Long noticeOwnerId);
 
     void deleteAllByUser(User user);
+
+    List<Notice> findAllByNoticeOwnerIdAndUserId(Long noticeOwnerId, Long userId);
 }

--- a/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
+++ b/src/main/java/com/devtraces/arterest/service/follow/FollowService.java
@@ -131,6 +131,9 @@ public class FollowService {
     public void deleteFollowRelation(Long userId, String nickname) {
         User unfollowTargetUser = findUserByNickname(nickname);
         followRepository.deleteByUserIdAndFollowingId(userId, unfollowTargetUser.getId());
+
+        // 팔로우 취소되는 유저, 팔로워 유저
+        noticeService.deleteNoticeWhenFollowingCanceled(unfollowTargetUser.getId(), userId);
     }
 
     // 팔로우 테이블의 가장 마지막 레코드(== 가장 최근 팔로우)를 찾아낸 후 캐시해 둠.

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -119,7 +119,6 @@ public class NoticeService {
                             feed,
                             reply,
                             reReply,
-                            NoticeType.REREPLY,
                             NoticeTarget.POST // 피드 주인을 대상으로 함
                     )
             );
@@ -138,7 +137,6 @@ public class NoticeService {
                             feed,
                             reply,
                             reReply,
-                            NoticeType.REREPLY,
                             NoticeTarget.REPLY // 댓글 주인을 대상으로 함
                     )
             );
@@ -245,7 +243,7 @@ public class NoticeService {
 
     private Notice buildReReplyNotice(
             Long ownerUserId, User sendUser, Feed feed, Reply reply,
-            Rereply reReply, NoticeType noticeType, NoticeTarget noticeTarget
+            Rereply reReply, NoticeTarget noticeTarget
     ) {
         return Notice.builder()
                 .noticeOwnerId(ownerUserId)
@@ -253,7 +251,7 @@ public class NoticeService {
                 .feed(feed)
                 .reply(reply)
                 .rereply(reReply)
-                .noticeType(noticeType)
+                .noticeType(NoticeType.REREPLY)
                 .noticeTarget(noticeTarget)
                 .build();
     }

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -1,7 +1,6 @@
 package com.devtraces.arterest.service.notice;
 
 import com.devtraces.arterest.common.exception.BaseException;
-import com.devtraces.arterest.common.exception.ErrorCode;
 import com.devtraces.arterest.common.type.NoticeTarget;
 import com.devtraces.arterest.common.type.NoticeType;
 import com.devtraces.arterest.controller.notice.dto.LikeNoticeDto;
@@ -204,6 +203,22 @@ public class NoticeService {
         }
 
         noticeRepository.delete(notice);
+    }
+
+    // 팔로워가 팔로잉 취소할 때 관련 알림도 삭제
+    @Transactional
+    public void deleteNoticeWhenFollowingCanceled(
+            Long noticeOwnerId, Long userId
+    ) {
+        List<Notice> notices = noticeRepository
+                .findAllByNoticeOwnerIdAndUserId(noticeOwnerId, userId);
+
+        // 팔로워 유저와 팔로잉 유저 사이의 알림 중 FOLLOW 알림만 삭제
+        for (Notice notice : notices) {
+            if (notice.getNoticeType().equals(NoticeType.FOLLOW)) {
+                noticeRepository.delete(notice);
+            }
+        }
     }
 
     private User getUser(Long userId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ server:
     encoding:
       charset: UTF-8
       force: true
+  tomcat:
+    keep-alive-timeout: 100
 
 spring:
   profiles:

--- a/src/test/java/com/devtraces/arterest/service/follow/FollowServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/follow/FollowServiceTest.java
@@ -372,6 +372,7 @@ class FollowServiceTest {
         given(userRepository.findByNickname("one")).willReturn(Optional.of(targetUser));
 
         doNothing().when(followRepository).deleteByUserIdAndFollowingId(2L, 1L);
+        doNothing().when(noticeService).deleteNoticeWhenFollowingCanceled(1L, 2L);
 
         // when
         followService.deleteFollowRelation(2L, "one");

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -36,6 +36,7 @@ import static com.devtraces.arterest.common.type.NoticeType.REPLY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -863,5 +864,38 @@ class NoticeServiceTest {
 
         //then
         assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+    }
+
+    @Test
+    void success_deleteNoticeWhenFollowingCanceled() {
+        //given
+        Long noticeOwnerId = 1L;
+        Long userId = 2L;
+
+        User user = User.builder().id(userId).build();
+        Notice followNotice = Notice.builder()
+                .noticeOwnerId(noticeOwnerId)
+                .user(user)
+                .noticeType(FOLLOW)
+                .build();
+
+        Notice likeNotice = Notice.builder()
+                .noticeOwnerId(noticeOwnerId)
+                .user(user)
+                .noticeType(LIKE)
+                .build();
+
+        ArrayList<Notice> list = new ArrayList<>();
+        list.add(followNotice);
+        list.add(likeNotice);
+
+        given(noticeRepository.findAllByNoticeOwnerIdAndUserId(anyLong(), anyLong()))
+                .willReturn(list);
+
+        //when
+        noticeService.deleteNoticeWhenFollowingCanceled(noticeOwnerId, userId);
+
+        //then
+        verify(noticeRepository, times(1)).delete(followNotice);
     }
 }


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #142 

## 📍 특이사항
* 팔로우 관계 삭제시 FOLLOW 알림도 삭제하는 로직을 FollowService와 NoticeService에 추가했습니다.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
