### PR TITLE
이메일 인증코드 확인 및 회원가입시 인증여부 확인 로직 추가

### DIFF
--- a/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
@@ -17,6 +17,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -43,12 +45,13 @@ public class AuthController {
 			@RequestParam @NotBlank(message = "username 입력은 필수입니다.") String username,
 			@RequestParam @NotBlank(message = "nickname 입력은 필수입니다.") String nickname,
 			@RequestParam(value = "profileImage", required = false) MultipartFile profileImage,
-			@RequestParam @Nullable String description
+			@RequestParam @Nullable String description,
+			@RequestParam @NotNull String signUpKey
 			) {
-		UserRegistrationResponse response = authService.register(
+		UserRegistrationResponse response = authService.signUp(
 				email, password,
 				username, nickname,
-				profileImage, description
+				profileImage, description, signUpKey
 		);
 		return ApiSuccessResponse.from(response);
 	}

--- a/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
@@ -48,7 +48,7 @@ public class AuthController {
 			@RequestParam @Nullable String description,
 			@RequestParam @NotNull String signUpKey
 			) {
-		UserRegistrationResponse response = authService.signUp(
+		UserRegistrationResponse response = authService.register(
 				email, password,
 				username, nickname,
 				profileImage, description, signUpKey

--- a/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/AuthController.java
@@ -63,8 +63,9 @@ public class AuthController {
 	@PostMapping("/email/auth-key/check")
 	public ApiSuccessResponse<MailAuthKeyCheckResponse> checkAuthKey(
 		@RequestBody @Valid MailAuthKeyCheckRequest request) {
-		boolean isCorrect = authService.checkAuthKey(request.getEmail(), request.getAuthKey());
-		return ApiSuccessResponse.from(new MailAuthKeyCheckResponse(isCorrect));
+		return ApiSuccessResponse.from(
+				authService.checkAuthKey(request.getEmail(), request.getAuthKey())
+		);
 	}
 
 	@PostMapping("/sign-in")

--- a/src/main/java/com/devtraces/arterest/controller/auth/dto/response/MailAuthKeyCheckResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/dto/response/MailAuthKeyCheckResponse.java
@@ -12,6 +12,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MailAuthKeyCheckResponse {
 
-	private boolean isCorrect;
+	private String signUpKey;
+	private boolean isIsCorrect;
 
+	public static MailAuthKeyCheckResponse from(String signUpKey, boolean isIsCorrect) {
+		return MailAuthKeyCheckResponse.builder()
+				.signUpKey(signUpKey)
+				.isIsCorrect(isIsCorrect)
+				.build();
+	}
 }

--- a/src/main/java/com/devtraces/arterest/controller/auth/dto/response/UserRegistrationResponse.java
+++ b/src/main/java/com/devtraces/arterest/controller/auth/dto/response/UserRegistrationResponse.java
@@ -18,14 +18,16 @@ public class UserRegistrationResponse {
 	private String nickname;
 	private String profileImageUrl;
 	private String description;
+	private boolean isIsSignUpKeyCorrect;
 
-	public static UserRegistrationResponse from(User user) {
+	public static UserRegistrationResponse from(User user, boolean isIsSignUpKeyCorrect) {
 		return UserRegistrationResponse.builder()
 			.email(user.getEmail())
 			.username(user.getUsername())
 			.nickname(user.getNickname())
 			.profileImageUrl(user.getProfileImageUrl())
 			.description(user.getDescription())
+			.isIsSignUpKeyCorrect(isIsSignUpKeyCorrect)
 			.build();
 	}
 }

--- a/src/main/java/com/devtraces/arterest/service/auth/AuthService.java
+++ b/src/main/java/com/devtraces/arterest/service/auth/AuthService.java
@@ -65,8 +65,19 @@ public class AuthService {
 	@Transactional
 	public UserRegistrationResponse register(
 			String email, String password, String username,
-			String nickname, MultipartFile profileImage, String description
+			String nickname, MultipartFile profileImage,
+			String description, String signUpKey
 	) {
+		String emailBySignUpKey =
+				redisService.getData(SIGN_UP_KEY + signUpKey);
+
+		// 이메일 인증이 안 된 사용자는 null, false 반환
+		if (!email.equals(emailBySignUpKey)) {
+			return UserRegistrationResponse.from(
+					User.builder().build(), false
+			);
+		}
+
 		validateRegistration(email, nickname);
 
 		String profileImageUrl = null;
@@ -85,7 +96,7 @@ public class AuthService {
 				.userStatus(UserStatusType.ACTIVE)
 				.build());
 
-		return UserRegistrationResponse.from(savedUser);
+		return UserRegistrationResponse.from(savedUser, true);
 	}
 
 	private void validateRegistration(String email, String nickname) {

--- a/src/test/java/com/devtraces/arterest/service/user/AuthServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/user/AuthServiceTest.java
@@ -1,19 +1,15 @@
 package com.devtraces.arterest.service.user;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.devtraces.arterest.common.type.UserSignUpType;
 import com.devtraces.arterest.common.type.UserStatusType;
+import com.devtraces.arterest.controller.auth.dto.response.MailAuthKeyCheckResponse;
 import com.devtraces.arterest.model.bookmark.BookmarkRepository;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.follow.FollowRepository;
@@ -30,8 +26,6 @@ import com.devtraces.arterest.common.exception.BaseException;
 import com.devtraces.arterest.common.jwt.JwtProvider;
 import com.devtraces.arterest.common.jwt.dto.TokenDto;
 import com.devtraces.arterest.service.auth.util.AuthRedisUtil;
-import com.devtraces.arterest.controller.auth.dto.request.UserRegistrationRequest;
-import com.devtraces.arterest.controller.auth.dto.response.UserRegistrationResponse;
 import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
 import com.devtraces.arterest.service.reply.ReplyService;
@@ -46,7 +40,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -87,6 +80,8 @@ class AuthServiceTest {
 	private RereplyRepository rereplyRepository;
 	@Mock
 	private FeedDeleteApplication feedDeleteApplication;
+	@Mock
+	private RedisService redisService;
 
 	@InjectMocks
 	private AuthService authService;
@@ -232,10 +227,13 @@ class AuthServiceTest {
 			.given(authRedisUtil).deleteAuthKeyValue(anyString());
 		willDoNothing()
 			.given(authRedisUtil).setAuthCompletedValue(anyString());
+		given(redisService.existKey(anyString())).willReturn(false);
 
-		boolean isCorrect = authService.checkAuthKey("example@gmail.com", "010101");
+		MailAuthKeyCheckResponse response =
+				authService.checkAuthKey("example@gmail.com", "010101");
 
-		assertTrue(isCorrect);
+		assertTrue(response.isIsCorrect());
+		assertNotNull(response.getSignUpKey());
 	}
 
 	// Redis에 정보가 없거나 그 값과 다른 경우
@@ -246,9 +244,11 @@ class AuthServiceTest {
 		given(authRedisUtil.getAuthKeyValue(anyString()))
 			.willReturn("111111");
 
-		boolean isCorrect = authService.checkAuthKey("example@gmail.com", "010101");
+		MailAuthKeyCheckResponse response =
+				authService.checkAuthKey("example@gmail.com", "010101");
 
-		assertFalse(isCorrect);
+		assertFalse(response.isIsCorrect());
+		assertNull(response.getSignUpKey());
 	}
 
 	@Test


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #147 

## 📍 특이사항
* 이메일 인증코드 확인 API에 signUpKey 필드를 추가했습니다.
* 회원가입 시 @RequestParam으로 받은 signUpKey를 기반으로 회원가입 성공/실패 여부를 나누었습니다.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
