### PR TITLE
피드/댓글/대댓글 삭제시 관련 알림도 삭제하는 기능 구현

### DIFF
--- a/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
@@ -22,4 +22,6 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     void deleteAllByRereplyId(Long rereplyId);
 
     void deleteAllByReplyId(Long replyId);
+
+    List<Notice> findALlByFeedId(Long feedId);
 }

--- a/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
@@ -18,4 +18,6 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     void deleteAllByUser(User user);
 
     List<Notice> findAllByNoticeOwnerIdAndUserId(Long noticeOwnerId, Long userId);
+
+    void deleteAllByRereplyId(Long rereplyId);
 }

--- a/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
@@ -20,4 +20,6 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     List<Notice> findAllByNoticeOwnerIdAndUserId(Long noticeOwnerId, Long userId);
 
     void deleteAllByRereplyId(Long rereplyId);
+
+    void deleteAllByReplyId(Long replyId);
 }

--- a/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
+++ b/src/main/java/com/devtraces/arterest/model/notice/NoticeRepository.java
@@ -23,5 +23,5 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     void deleteAllByReplyId(Long replyId);
 
-    List<Notice> findALlByFeedId(Long feedId);
+    List<Notice> findAllByFeedId(Long feedId);
 }

--- a/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplication.java
@@ -7,6 +7,7 @@ import com.devtraces.arterest.service.feed.FeedDeleteService;
 import com.devtraces.arterest.service.feed.FeedReadService;
 import com.devtraces.arterest.service.hashtag.HashtagService;
 import com.devtraces.arterest.service.like.LikeService;
+import com.devtraces.arterest.service.notice.NoticeService;
 import com.devtraces.arterest.service.reply.ReplyService;
 import com.devtraces.arterest.service.rereply.RereplyService;
 import com.devtraces.arterest.service.s3.S3Service;
@@ -27,6 +28,7 @@ public class FeedDeleteApplication {
     private final BookmarkService bookmarkService;
     private final RereplyService rereplyService;
     private final ReplyService replyService;
+    private final NoticeService noticeService;
 
     // TODO 스프링 @Async를 사용해서 비동기 멀티 스레딩으로 처리하면 응답지연시간 최소화 가능.
     @Transactional
@@ -59,8 +61,10 @@ public class FeedDeleteApplication {
         // 댓글 삭제
         replyService.deleteAllFeedRelatedReply(deleteTargetFeed);
 
-        // 마지막으로 피드 삭제.
+        // 삭제하는 피드와 관련된 알림 삭제
+        noticeService.deleteNoticeWhenFeedDeleted(feedId);
+
+        // 마지막으로 피드 삭제
         feedDeleteService.deleteFeedEntity(feedId);
     }
-
 }

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -233,11 +233,9 @@ public class NoticeService {
 
     @Transactional
     public void deleteNoticeWhenFeedDeleted(Long feedId) {
-        List<Notice> notices = noticeRepository.findALlByFeedId(feedId);
+        List<Notice> notices = noticeRepository.findAllByFeedId(feedId);
         if (notices.size() > 0) {
-            for (Notice notice : notices) {
-                noticeRepository.delete(notice);
-            }
+            noticeRepository.deleteAll(notices);
         }
     }
 

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -231,6 +231,15 @@ public class NoticeService {
         noticeRepository.deleteAllByReplyId(replyId);
     }
 
+    @Transactional
+    public void deleteNoticeWhenFeedDeleted(Long feedId) {
+        List<Notice> notices = noticeRepository.findALlByFeedId(feedId);
+        if (notices.size() > 0) {
+            for (Notice notice : notices) {
+                noticeRepository.delete(notice);
+            }
+        }
+    }
 
     private User getUser(Long userId) {
         return userRepository.findById(userId).orElseThrow(

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -226,6 +226,12 @@ public class NoticeService {
         noticeRepository.deleteAllByRereplyId(rereplyId);
     }
 
+    @Transactional
+    public void deleteNoticeWhenReplyDeleted(Long replyId) {
+        noticeRepository.deleteAllByReplyId(replyId);
+    }
+
+
     private User getUser(Long userId) {
         return userRepository.findById(userId).orElseThrow(
                 () -> BaseException.USER_NOT_FOUND);

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -219,6 +219,13 @@ public class NoticeService {
         }
     }
 
+    // 대댓글이 삭제되면 해당 대댓글의 알림을 가져올 때 에러가 발생
+    // 대댓글이 삭제될 때 대댓글 id를 가진 알림들 다 삭제
+    @Transactional
+    public void deleteNoticeWhenRereplyDeleted(Long rereplyId) {
+        noticeRepository.deleteAllByRereplyId(rereplyId);
+    }
+
     private User getUser(Long userId) {
         return userRepository.findById(userId).orElseThrow(
                 () -> BaseException.USER_NOT_FOUND);

--- a/src/main/java/com/devtraces/arterest/service/reply/ReplyService.java
+++ b/src/main/java/com/devtraces/arterest/service/reply/ReplyService.java
@@ -129,6 +129,10 @@ public class ReplyService {
     @Async
     @Transactional
     public void deleteAllFeedRelatedReply(Feed feed){
+        for (Reply reply : feed.getReplyList()) {
+            noticeService.deleteNoticeWhenReplyDeleted(reply.getId());
+        }
+
         replyRepository.deleteAllByIdIn(
             feed.getReplyList().stream().map(Reply::getId).collect(Collectors.toList())
         );

--- a/src/main/java/com/devtraces/arterest/service/reply/ReplyService.java
+++ b/src/main/java/com/devtraces/arterest/service/reply/ReplyService.java
@@ -101,6 +101,14 @@ public class ReplyService {
         if(!Objects.equals(reply.getUser().getId(), userId)){
             throw BaseException.USER_INFO_NOT_MATCH;
         }
+
+        // 댓글과 관련된 대댓글들의 알림들 삭제
+        // TODO : 아래 대댓글 삭제하는 로직과 합치면 중복없이 깔끔해질 것 같음. 리팩토링 필요
+        List<Rereply> rereplyList = reply.getRereplyList();
+        for (Rereply rereply : rereplyList) {
+            noticeService.deleteNoticeWhenRereplyDeleted(rereply.getId());
+        }
+
         // 댓글에 달려 있는 대댓글을 삭제한다.
         if(reply.getRereplyList() != null && reply.getRereplyList().size() > 0){
             rereplyRepository.deleteAllByIdIn(
@@ -110,6 +118,9 @@ public class ReplyService {
 
         // 게시물의 댓글 개수을 1개 차감한다.
         reply.getFeed().minusOneReply();
+
+        // 댓글 삭제시 댓글 관련 알림도 남아있으면 삭제
+        noticeService.deleteNoticeWhenReplyDeleted(replyId);
 
         // 댓글을 삭제한다.
         replyRepository.deleteById(replyId);

--- a/src/main/java/com/devtraces/arterest/service/rereply/RereplyService.java
+++ b/src/main/java/com/devtraces/arterest/service/rereply/RereplyService.java
@@ -109,6 +109,10 @@ public class RereplyService {
     @Transactional
     public void deleteAllFeedRelatedRereply(Feed feed){
         for(Reply reply : feed.getReplyList()){
+            for (Rereply rereply : reply.getRereplyList()) {
+                noticeService.deleteNoticeWhenRereplyDeleted(rereply.getId());
+            }
+
             if(reply.getRereplyList().size() > 0){
                 rereplyRepository.deleteAllByIdIn(
                     reply.getRereplyList().stream().map(Rereply::getId)

--- a/src/main/java/com/devtraces/arterest/service/rereply/RereplyService.java
+++ b/src/main/java/com/devtraces/arterest/service/rereply/RereplyService.java
@@ -99,6 +99,9 @@ public class RereplyService {
         // 삭제되는 대댓글이 달려 있는 댓글의 개수를 1개 차감한다.
         rereply.getReply().minusOneRereply();
 
+        // 대댓글 삭제될 때 관련 알림도 삭제하기
+        noticeService.deleteNoticeWhenRereplyDeleted(rereplyId);
+
         rereplyRepository.deleteById(rereplyId);
     }
 

--- a/src/test/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplicationTest.java
+++ b/src/test/java/com/devtraces/arterest/service/feed/application/FeedDeleteApplicationTest.java
@@ -1,8 +1,7 @@
 package com.devtraces.arterest.service.feed.application;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
@@ -17,6 +16,7 @@ import com.devtraces.arterest.service.feed.FeedDeleteService;
 import com.devtraces.arterest.service.feed.FeedReadService;
 import com.devtraces.arterest.service.hashtag.HashtagService;
 import com.devtraces.arterest.service.like.LikeService;
+import com.devtraces.arterest.service.notice.NoticeService;
 import com.devtraces.arterest.service.reply.ReplyService;
 import com.devtraces.arterest.service.rereply.RereplyService;
 import com.devtraces.arterest.service.s3.S3Service;
@@ -51,6 +51,8 @@ class FeedDeleteApplicationTest {
     private RereplyService rereplyService;
     @Mock
     private ReplyService replyService;
+    @Mock
+    private NoticeService noticeService;
     @InjectMocks
     private FeedDeleteApplication feedDeleteApplication;
 
@@ -75,6 +77,7 @@ class FeedDeleteApplicationTest {
         doNothing().when(bookmarkService).deleteAllFeedRelatedBookmark(1L);
         doNothing().when(rereplyService).deleteAllFeedRelatedRereply(any());
         doNothing().when(replyService).deleteAllFeedRelatedReply(any());
+        doNothing().when(noticeService).deleteNoticeWhenFeedDeleted(anyLong());
         doNothing().when(feedDeleteService).deleteFeedEntity(1L);
 
         // when
@@ -88,6 +91,7 @@ class FeedDeleteApplicationTest {
         verify(bookmarkService, times(1)).deleteAllFeedRelatedBookmark(1L);
         verify(rereplyService, times(1)).deleteAllFeedRelatedRereply(any());
         verify(replyService, times(1)).deleteAllFeedRelatedReply(any());
+        verify(noticeService, times(1)).deleteNoticeWhenFeedDeleted(anyLong());
         verify(feedDeleteService, times(1)).deleteFeedEntity(1L);
     }
 

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -923,4 +923,23 @@ class NoticeServiceTest {
         verify(noticeRepository, times(1))
                 .deleteAllByReplyId(replyId);
     }
+
+    @Test
+    void succes_deleteNoticeWhenFeedDeleted() {
+        //given
+        Long feedId = 1L;
+
+        Feed feed = Feed.builder().id(feedId).build();
+        Notice notice = Notice.builder().feed(feed).build();
+        ArrayList<Notice> notices = new ArrayList<>();
+        notices.add(notice);
+
+        given(noticeRepository.findAllByFeedId(anyLong())).willReturn(notices);
+
+        //when
+        noticeService.deleteNoticeWhenFeedDeleted(feedId);
+
+        //then
+        verify(noticeRepository, times(1)).deleteAll(any());
+    }
 }

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -36,7 +36,6 @@ import static com.devtraces.arterest.common.type.NoticeType.REPLY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -897,5 +896,18 @@ class NoticeServiceTest {
 
         //then
         verify(noticeRepository, times(1)).delete(followNotice);
+    }
+
+    @Test
+    void success_deleteNoticeWhenRereplyDelete() {
+        //given
+        Long rereplyId = 324L;
+
+        //when
+        noticeService.deleteNoticeWhenRereplyDeleted(rereplyId);
+
+        //then
+        verify(noticeRepository, times(1))
+                .deleteAllByRereplyId(rereplyId);
     }
 }

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -910,4 +910,17 @@ class NoticeServiceTest {
         verify(noticeRepository, times(1))
                 .deleteAllByRereplyId(rereplyId);
     }
+
+    @Test
+    void success_deleteNoticeWhenReplyDeleted() {
+        //given
+        Long replyId = 1L;
+
+        //when
+        noticeService.deleteNoticeWhenReplyDeleted(replyId);
+
+        //then
+        verify(noticeRepository, times(1))
+                .deleteAllByReplyId(replyId);
+    }
 }

--- a/src/test/java/com/devtraces/arterest/service/reply/ReplyServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/reply/ReplyServiceTest.java
@@ -390,6 +390,7 @@ class ReplyServiceTest {
         feed.getReplyList().add(reply);
 
         doNothing().when(replyRepository).deleteAllByIdIn(anyList());
+        doNothing().when(noticeService).deleteNoticeWhenReplyDeleted(anyLong());
 
         // when
         replyService.deleteAllFeedRelatedReply(feed);

--- a/src/test/java/com/devtraces/arterest/service/reply/ReplyServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/reply/ReplyServiceTest.java
@@ -319,6 +319,8 @@ class ReplyServiceTest {
 
         given(replyRepository.findById(anyLong())).willReturn(Optional.of(reply));
         doNothing().when(rereplyRepository).deleteAllByIdIn(anyList());
+        doNothing().when(noticeService).deleteNoticeWhenRereplyDeleted(anyLong());
+        doNothing().when(noticeService).deleteNoticeWhenReplyDeleted(anyLong());
 
         // when
         replyService.deleteReply(1L, 1L);

--- a/src/test/java/com/devtraces/arterest/service/rereply/RereplyServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/rereply/RereplyServiceTest.java
@@ -307,6 +307,7 @@ class RereplyServiceTest {
         reply.getRereplyList().add(rereply);
 
         given(rereplyRepository.findById(anyLong())).willReturn(Optional.of(rereply));
+        doNothing().when(noticeService).deleteNoticeWhenRereplyDeleted(anyLong());
         doNothing().when(rereplyRepository).deleteById(anyLong());
 
         // when

--- a/src/test/java/com/devtraces/arterest/service/rereply/RereplyServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/rereply/RereplyServiceTest.java
@@ -382,6 +382,7 @@ class RereplyServiceTest {
         feed.getReplyList().add(reply);
 
         doNothing().when(rereplyRepository).deleteAllByIdIn(anyList());
+        doNothing().when(noticeService).deleteNoticeWhenRereplyDeleted(anyLong());
 
         // when
         rereplyService.deleteAllFeedRelatedRereply(feed);


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #154 

## 📍 특이사항
* 대댓글 삭제시 대댓글 관련 알림 삭제 기능을 추가했습니다.
* 댓글 삭제시 댓글과 댓글의 대댓글 알림을 삭제하는 기능을 추가했습니다.
* 피드 삭제시 피드와 댓글, 대댓글 알림을 삭제하는 기능을 추가했습니다. 
    * FK 문제가 있어 대댓글 알림, 댓글 알림, 피드 알림 순으로 삭제하는 기능을 추가했습니다.
    * FeedDeleteApplication에서 deleteRelatedReply 실행시 FK 참조 오류가 발생하는 것 같습니다. 이 부분 확인해야할것 같습니다. 

* 에러 로그 
<img width="1234" alt="스크린샷 2023-03-07 오전 1 24 35" src="https://user-images.githubusercontent.com/81020108/223170700-689d875b-b179-441e-9c74-eb4c37138afb.png">

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
