### PR TITLE
사용자 탈퇴시 관련 알림 삭제 기능 구현

### DIFF
--- a/src/main/java/com/devtraces/arterest/service/auth/AuthService.java
+++ b/src/main/java/com/devtraces/arterest/service/auth/AuthService.java
@@ -12,7 +12,6 @@ import com.devtraces.arterest.model.bookmark.BookmarkRepository;
 import com.devtraces.arterest.model.feed.Feed;
 import com.devtraces.arterest.model.follow.FollowRepository;
 import com.devtraces.arterest.model.like.LikeRepository;
-import com.devtraces.arterest.model.notice.NoticeRepository;
 import com.devtraces.arterest.model.reply.Reply;
 import com.devtraces.arterest.model.reply.ReplyRepository;
 import com.devtraces.arterest.model.rereply.Rereply;
@@ -23,6 +22,7 @@ import com.devtraces.arterest.service.auth.util.AuthRedisUtil;
 import com.devtraces.arterest.service.auth.util.TokenRedisUtil;
 import com.devtraces.arterest.service.feed.application.FeedDeleteApplication;
 import com.devtraces.arterest.service.mail.MailService;
+import com.devtraces.arterest.service.notice.NoticeService;
 import com.devtraces.arterest.service.reply.ReplyService;
 import com.devtraces.arterest.service.rereply.RereplyService;
 import com.devtraces.arterest.service.s3.S3Service;
@@ -57,7 +57,7 @@ public class AuthService {
 	private final UserRepository userRepository;
 	private final FeedDeleteApplication feedDeleteApplication;
 	private final FollowRepository followRepository;
-	private final NoticeRepository noticeRepository;
+	private final NoticeService noticeService;
 	private final BookmarkRepository bookmarkRepository;
 	private final LikeRepository likeRepository;
 	private final ReplyRepository replyRepository;
@@ -234,6 +234,9 @@ public class AuthService {
 				);
 			}
 		}
+
+		// 유저와 관련된 알림 삭제
+		noticeService.deleteNoticeWhenUserDeleted(user.getId());
 
 		//유저 삭제
 		userRepository.deleteById(userId);

--- a/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
+++ b/src/main/java/com/devtraces/arterest/service/notice/NoticeService.java
@@ -239,6 +239,11 @@ public class NoticeService {
         }
     }
 
+    @Transactional
+    public void deleteNoticeWhenUserDeleted(Long userId) {
+        noticeRepository.deleteAllByUser(getUser(userId));
+    }
+
     private User getUser(Long userId) {
         return userRepository.findById(userId).orElseThrow(
                 () -> BaseException.USER_NOT_FOUND);

--- a/src/main/java/com/devtraces/arterest/service/reply/ReplyService.java
+++ b/src/main/java/com/devtraces/arterest/service/reply/ReplyService.java
@@ -92,7 +92,6 @@ public class ReplyService {
         return ReplyResponse.from(reply);
     }
 
-    @Async
     @Transactional
     public void deleteReply(Long userId, Long replyId) {
         Reply reply = replyRepository.findById(replyId).orElseThrow(

--- a/src/main/java/com/devtraces/arterest/service/rereply/RereplyService.java
+++ b/src/main/java/com/devtraces/arterest/service/rereply/RereplyService.java
@@ -85,8 +85,7 @@ public class RereplyService {
         rereply.updateContent(rereplyRequest.getContent());
         return RereplyResponse.from(rereplyRepository.save(rereply), feedId);
     }
-
-    @Async
+    
     @Transactional
     public void deleteRereply(Long userId, Long rereplyId) {
         Rereply rereply = rereplyRepository.findById(rereplyId).orElseThrow(

--- a/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/notice/NoticeServiceTest.java
@@ -942,4 +942,36 @@ class NoticeServiceTest {
         //then
         verify(noticeRepository, times(1)).deleteAll(any());
     }
+
+    @Test
+    void success_deleteNoticeWhenUserDeleted() {
+        //given
+        Long userId = 1L;
+        User user = User.builder().id(userId).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+
+        //when
+        noticeService.deleteNoticeWhenUserDeleted(userId);
+
+        //then
+        verify(noticeRepository, times(1))
+                .deleteAllByUser(user);
+
+    }
+
+    @Test
+    void fail_deleteNoticeWhenUserDeleted_USER_NOT_FOUND() {
+        //given
+        Long userId = 1L;
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //when
+        BaseException exception = assertThrows(
+                BaseException.class,
+                () -> noticeService.deleteNoticeWhenUserDeleted(userId)
+        );
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
 }

--- a/src/test/java/com/devtraces/arterest/service/user/AuthServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/user/AuthServiceTest.java
@@ -29,6 +29,7 @@ import com.devtraces.arterest.common.jwt.dto.TokenDto;
 import com.devtraces.arterest.service.auth.util.AuthRedisUtil;
 import com.devtraces.arterest.model.user.User;
 import com.devtraces.arterest.model.user.UserRepository;
+import com.devtraces.arterest.service.notice.NoticeService;
 import com.devtraces.arterest.service.reply.ReplyService;
 import com.devtraces.arterest.service.rereply.RereplyService;
 import java.util.ArrayList;
@@ -68,8 +69,6 @@ class AuthServiceTest {
 	@Mock
 	private S3Service s3Service;
 	@Mock
-	private NoticeRepository noticeRepository;
-	@Mock
 	private FollowRepository followRepository;
 	@Mock
 	private BookmarkRepository bookmarkRepository;
@@ -83,6 +82,8 @@ class AuthServiceTest {
 	private FeedDeleteApplication feedDeleteApplication;
 	@Mock
 	private RedisService redisService;
+	@Mock
+	private NoticeService noticeService;
 
 	@InjectMocks
 	private AuthService authService;
@@ -419,8 +420,6 @@ class AuthServiceTest {
 			.build();
 		given(userRepository.findById(anyLong()))
 			.willReturn(Optional.ofNullable(user));
-		willDoNothing().given(noticeRepository).deleteAllByNoticeOwnerId(anyLong());
-		willDoNothing().given(noticeRepository).deleteAllByUser(any());
 		willDoNothing().given(followRepository).deleteAllByFollowingId(anyLong());
 		willDoNothing().given(followRepository).deleteAllByUser(any());
 		willDoNothing().given(feedDeleteApplication).deleteFeed(anyLong(),any());
@@ -435,6 +434,8 @@ class AuthServiceTest {
 			.willReturn(Optional.ofNullable(Rereply.builder().id(4L).build()));
 		willDoNothing().given(rereplyService).deleteRereply(anyLong(),any());
 
+		willDoNothing().given(noticeService).deleteNoticeWhenUserDeleted(anyLong());
+
 		willDoNothing().given(userRepository).deleteById(any());
 
 		// when
@@ -442,8 +443,6 @@ class AuthServiceTest {
 
 		// then
 		verify(userRepository, times(1)).findById(1L);
-		verify(noticeRepository, times(1)).deleteAllByNoticeOwnerId(1L);
-		verify(noticeRepository, times(1)).deleteAllByUser(user);
 		verify(followRepository, times(1)).deleteAllByFollowingId(1L);
 		verify(followRepository, times(1)).deleteAllByUser(user);
 		verify(feedDeleteApplication, times(1)).deleteFeed(1L, 2L);
@@ -453,6 +452,7 @@ class AuthServiceTest {
 		verify(replyService, times(1)).deleteReply(1L, 3L);
 		verify(rereplyRepository, times(1)).findById(4L);
 		verify(rereplyService, times(1)).deleteRereply(1L, 4L);
+		verify(noticeService, times(1)).deleteNoticeWhenUserDeleted(1L);
 		verify(userRepository, times(1)).deleteById(1L);
 	}
 


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #154 

## 📍 특이사항
* 사용자 탈퇴 시 그와 관련된 모든 알림을 삭제하는 기능을 구현했습니다.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
