### PR TITLE
fix: 해시태그 관련 오류 수정 (#160)

### DIFF
--- a/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
@@ -69,23 +69,37 @@ public class FeedService {
         // FeedHashtagMap에 저장한다.
         // FeedHashtagMap 엔티티를 빌드하기 위해서는 Feed 엔티티와 Hashtag 엔티티 모두가 필요하다.
         // 해시태그의 앞뒤 공백을 제거하고 해시태그가 중복인 경우 1개로 취급한다.
-        hashtagList = hashtagList.stream().map(String::trim).collect(Collectors.toSet()).stream().collect(Collectors.toList());
+        if(hashtagList != null) {
+            hashtagList = hashtagList.stream().map(String::trim).collect(Collectors.toSet())
+                .stream().collect(Collectors.toList());
+        }
 
         if(hashtagList != null){
             for(String hashtagInputString : hashtagList){
-                Hashtag hashtagEntity = hashtagRepository.findByHashtagString(hashtagInputString).orElse(
-                    hashtagRepository.save(
-                        Hashtag.builder()
-                            .hashtagString(hashtagInputString)
+                Optional<Hashtag> optionalHashtag = hashtagRepository.findByHashtagString(hashtagInputString);
+                // 존재하지 않는 새로운 해시태그다.
+                if(!optionalHashtag.isPresent()){
+                    System.out.println("새로운 해시태그!!");
+                    Hashtag newHashtag = Hashtag.builder()
+                        .hashtagString(hashtagInputString)
+                        .build();
+                    hashtagRepository.save(newHashtag);
+                    feedHashtagMapRepository.save(
+                        FeedHashtagMap.builder()
+                            .feed(newFeed)
+                            .hashtag(newHashtag)
                             .build()
-                    )
-                );
-                feedHashtagMapRepository.save(
-                    FeedHashtagMap.builder()
-                        .feed(newFeed)
-                        .hashtag(hashtagEntity)
-                        .build()
-                );
+                    );
+                } else {
+                    // 이미 존재하는 해시태그다. 해시태그리포지토리는 더 볼 필요 없고,
+                    // 피드해시태그맵 리포지토리만 초기화 해주면 된다.
+                    feedHashtagMapRepository.save(
+                        FeedHashtagMap.builder()
+                            .feed(newFeed)
+                            .hashtag(optionalHashtag.get())
+                            .build()
+                    );
+                }
             }
         }
 
@@ -164,7 +178,10 @@ public class FeedService {
 
         // 그 후 입력 받은 값에 따라서 새롭게 저장한다.
         // 해시태그의 앞뒤 공백을 제거하고 해시태그가 중복인 경우 1개로 취급한다.
-        hashtagList = hashtagList.stream().map(String::trim).collect(Collectors.toSet()).stream().collect(Collectors.toList());
+        if(hashtagList != null) {
+            hashtagList = hashtagList.stream().map(String::trim).collect(Collectors.toSet())
+                .stream().collect(Collectors.toList());
+        }
 
         if(hashtagList != null){
             for(String hashtagInputString : hashtagList){


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #160 

## 📍 특이사항
- 게시물 생성 및 수정 시 해시태그가 아예 없거나, 동일한 해시태그를 여러개 포함하거나, 이전 게시글들의 해시태그와 겹치는 해시태그를 가지고 있을 경우 발생한 FK 관련 에러 및 Null Pointer Exception 에러들을 바로잡음.
- FE에서 해시태그 리스트가 null 로 오는 경우에 대해서도 오류 전부 바로 잡음
- 게시물 생성시 orElse(...) 보다는 Optionlal 을 이용해서 처리함으로써 로직이 확실히 동작함을 보장하게 만듦.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
