### PR TITLE
카카오 로그인시 kakaoUserId로 사용자 식별하는 로직으로 수정

### DIFF
--- a/src/test/java/com/devtraces/arterest/service/auth/OauthServiceTest.java
+++ b/src/test/java/com/devtraces/arterest/service/auth/OauthServiceTest.java
@@ -82,8 +82,6 @@ class OauthServiceTest {
                 )
                 .build();
 
-        given(userRepository.findByUsername(anyString()))
-                .willReturn(Optional.empty());
         given(userRepository.findByKakaoUserId(anyLong()))
                 .willReturn(Optional.empty());
         given(passwordEncoder.encode(anyString())).willReturn(encodedPassword);
@@ -146,7 +144,7 @@ class OauthServiceTest {
             )
                 .build();
 
-        given(userRepository.findByUsername(anyString()))
+        given(userRepository.findByKakaoUserId(anyLong()))
                 .willReturn(Optional.of(user));
         given(jwtProvider.generateAccessTokenAndRefreshToken(user.getId()))
                 .willReturn(tokenDto);
@@ -159,41 +157,5 @@ class OauthServiceTest {
         assertEquals(tokenDto.getAccessTokenCookie().getValue(), response.getAcceesTokenCookie().getValue());
         assertEquals(tokenDto.getRefreshTokenCookie().getValue(), response.getRefreshTokenCookie().getValue());
         assertEquals(user.getNickname(), response.getNickname());
-    }
-
-    @Test
-    @DisplayName("카카오 소셜 로그인 실패 - 일반 회원가입으로 가입한 유저")
-    void fail_kakaoSignUpOrSignIn_ALREADY_EXIST_USER() {
-        //given
-        UserInfoFromKakaoDto dto = UserInfoFromKakaoDto.builder()
-                .kakaoUserId(320482824L)
-                .email("example@abc.com")
-                .username("username")
-                .nickname("randomNickname")
-                .profileImageUrl("profileImageUrl")
-                .description("description")
-                .build();
-
-        User user = User.builder()
-                .id(1L)
-                .email(dto.getEmail())
-                .username(dto.getUsername())
-                .nickname(dto.getNickname())
-                .profileImageUrl(dto.getProfileImageUrl())
-                .description(dto.getDescription())
-                .userStatus(UserStatusType.ACTIVE)
-                .signupType(UserSignUpType.EMAIL)
-                .build();
-
-        given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
-
-        //when
-        BaseException exception = assertThrows(
-                BaseException.class,
-                () -> oauthService.kakaoSignUpOrSignIn(dto)
-        );
-
-        //then
-        assertEquals(ErrorCode.ALREADY_EXIST_USER, exception.getErrorCode());
     }
 }


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
* #159 

## 📍 특이사항
* 카카오 로그인시 임의의 닉네임을 가지기 때문에 kakaoUserId로 사용자를 식별해 회원가입/로그인을 구분해서 진행합니다. 
* API 테스트는 배포 후 웹에서 실행해볼 예정입니다.

## 📍 테스트
- [x] 단위 테스트
