### PR TITLE
게시물 생성/수정 시 해시태그 관련 오류 해결

### DIFF
--- a/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
@@ -79,7 +79,6 @@ public class FeedService {
                 Optional<Hashtag> optionalHashtag = hashtagRepository.findByHashtagString(hashtagInputString);
                 // 존재하지 않는 새로운 해시태그다.
                 if(!optionalHashtag.isPresent()){
-                    System.out.println("새로운 해시태그!!");
                     Hashtag newHashtag = Hashtag.builder()
                         .hashtagString(hashtagInputString)
                         .build();

--- a/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
+++ b/src/main/java/com/devtraces/arterest/service/feed/FeedService.java
@@ -69,23 +69,37 @@ public class FeedService {
         // FeedHashtagMap에 저장한다.
         // FeedHashtagMap 엔티티를 빌드하기 위해서는 Feed 엔티티와 Hashtag 엔티티 모두가 필요하다.
         // 해시태그의 앞뒤 공백을 제거하고 해시태그가 중복인 경우 1개로 취급한다.
-        hashtagList = hashtagList.stream().map(String::trim).collect(Collectors.toSet()).stream().collect(Collectors.toList());
+        if(hashtagList != null){
+            hashtagList = hashtagList.stream().map(String::trim).collect(Collectors.toSet())
+                .stream().collect(Collectors.toList());
+        }
 
         if(hashtagList != null){
             for(String hashtagInputString : hashtagList){
-                Hashtag hashtagEntity = hashtagRepository.findByHashtagString(hashtagInputString).orElse(
-                    hashtagRepository.save(
-                        Hashtag.builder()
-                            .hashtagString(hashtagInputString)
+                Optional<Hashtag> optionalHashtag = hashtagRepository.findByHashtagString(hashtagInputString);
+                // 존재하지 않는 새로운 해시태그다.
+                if(!optionalHashtag.isPresent()){
+                    System.out.println("새로운 해시태그!!");
+                    Hashtag newHashtag = Hashtag.builder()
+                        .hashtagString(hashtagInputString)
+                        .build();
+                    hashtagRepository.save(newHashtag);
+                    feedHashtagMapRepository.save(
+                        FeedHashtagMap.builder()
+                            .feed(newFeed)
+                            .hashtag(newHashtag)
                             .build()
-                    )
-                );
-                feedHashtagMapRepository.save(
-                    FeedHashtagMap.builder()
-                        .feed(newFeed)
-                        .hashtag(hashtagEntity)
-                        .build()
-                );
+                    );
+                } else {
+                    // 이미 존재하는 해시태그다. 해시태그리포지토리는 더 볼 필요 없고,
+                    // 피드해시태그맵 리포지토리만 초기화 해주면 된다.
+                    feedHashtagMapRepository.save(
+                        FeedHashtagMap.builder()
+                            .feed(newFeed)
+                            .hashtag(optionalHashtag.get())
+                            .build()
+                    );
+                }
             }
         }
 
@@ -164,7 +178,10 @@ public class FeedService {
 
         // 그 후 입력 받은 값에 따라서 새롭게 저장한다.
         // 해시태그의 앞뒤 공백을 제거하고 해시태그가 중복인 경우 1개로 취급한다.
-        hashtagList = hashtagList.stream().map(String::trim).collect(Collectors.toSet()).stream().collect(Collectors.toList());
+        if(hashtagList != null) {
+            hashtagList = hashtagList.stream().map(String::trim).collect(Collectors.toSet())
+                .stream().collect(Collectors.toList());
+        }
 
         if(hashtagList != null){
             for(String hashtagInputString : hashtagList){
@@ -219,6 +236,8 @@ public class FeedService {
                 builder.append(",");
             }
             feed.setHashtagStringValues(builder.toString());
+        } else {
+            feed.setHashtagStringValues(null);
         }
     }
 }


### PR DESCRIPTION
<!-- PR은 코드 충돌이 최소화되도록 최대한 작은 단위로 자주 올려주세요! -->
<!-- Service의 커버리지가 100%가 아닐 경우 특이사항에 이유를 작성해주세요. -->

## 📍 관련 이슈
- #160 

## 📍 특이사항
- 한 게시물 안에서 동일한 해시태그 두 개 이상 갖고 있는 상태로 생성/수정 요청할 때,
- 이전 게시물과 동일한 해시태그로 게시물 생성/수정할 때,
- 해시태그 리스트가 FE에서 Null 로 들어올 때
- 이렇게 3가지 상황에서 발생한 FK 오류, Null Pointer Exception 오류들을 바로잡음.
- 게시물 생성시 orElse(...) 보다는 Optionlal 을 이용해서 처리함으로써 로직이 확실히 동작함을 보장하게 만듦.

## 📍 테스트
- [x] API Test
- [x] 단위 테스트
