### PR TITLE
로그아웃 이후 토큰 재발급 시 예외 발생 로직 수정

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
+++ b/src/main/java/com/devtraces/arterest/common/exception/BaseException.java
@@ -17,14 +17,14 @@ public class BaseException extends RuntimeException {
 	public static final BaseException WRONG_EMAIL_OR_PASSWORD = new BaseException(ErrorCode.WRONG_EMAIL_OR_PASSWORD);
 	public static final BaseException WRONG_BEFORE_PASSWORD = new BaseException(ErrorCode.WRONG_BEFORE_PASSWORD);
 	public static final BaseException NOT_EXPIRED_ACCESS_TOKEN = new BaseException(ErrorCode.NOT_EXPIRED_ACCESS_TOKEN);
-  public static final BaseException INVALID_IMAGE_EXTENSION = new BaseException(ErrorCode.INVALID_IMAGE_EXTENSION);
+  	public static final BaseException INVALID_IMAGE_EXTENSION = new BaseException(ErrorCode.INVALID_IMAGE_EXTENSION);
 	public static final BaseException INVALID_TOKEN = new BaseException(ErrorCode.INVALID_TOKEN);
 	public static final BaseException FORBIDDEN = new BaseException(ErrorCode.FORBIDDEN);
 	public static final BaseException EXPIRED_OR_PREVIOUS_REFRESH_TOKEN = new BaseException(ErrorCode.EXPIRED_OR_PREVIOUS_REFRESH_TOKEN);
 	public static final BaseException USER_NOT_FOUND = new BaseException(ErrorCode.USER_NOT_FOUND);
 	public static final BaseException FEED_NOT_FOUND = new BaseException(ErrorCode.FEED_NOT_FOUND);
 	public static final BaseException NOTICE_NOT_FOUND = new BaseException(ErrorCode.NOTICE_NOT_FOUND);
-  public static final BaseException FAILED_FILE_UPLOAD = new BaseException(ErrorCode.FAILED_FILE_UPLOAD);
+  	public static final BaseException FAILED_FILE_UPLOAD = new BaseException(ErrorCode.FAILED_FILE_UPLOAD);
 	public static final BaseException FAILED_CACHE_GET_OPERATION = new BaseException(ErrorCode.FAILED_CACHE_GET_OPERATION);
 	public static final BaseException HASHTAG_LIMIT_EXCEED = new BaseException(ErrorCode.HASHTAG_LIMIT_EXCEED);
 	public static final BaseException IMAGE_FILE_COUNT_LIMIT_EXCEED = new BaseException(ErrorCode.IMAGE_FILE_COUNT_LIMIT_EXCEED);
@@ -36,7 +36,7 @@ public class BaseException extends RuntimeException {
 	public static final BaseException FOLLOWING_SELF_NOT_ALLOWED = new BaseException(ErrorCode.FOLLOWING_SELF_NOT_ALLOWED);
 	public static final BaseException DUPLICATED_FOLLOW_OR_LIKE = new BaseException(ErrorCode.DUPLICATED_FOLLOW_OR_LIKE);
 	public static final BaseException LIKE_NUMBER_BELLOW_ZERO = new BaseException(ErrorCode.LIKE_NUMBER_BELLOW_ZERO);
-  public static final BaseException ALREADY_EXIST_USER = new BaseException(ErrorCode.ALREADY_EXIST_USER);
+  	public static final BaseException ALREADY_EXIST_USER = new BaseException(ErrorCode.ALREADY_EXIST_USER);
 	public static final BaseException UPDATE_PASSWORD_NOT_ALLOWED_FOR_KAKAO_USER = new BaseException(ErrorCode.UPDATE_PASSWORD_NOT_ALLOWED_FOR_KAKAO_USER);
 
 

--- a/src/main/java/com/devtraces/arterest/service/auth/util/TokenRedisUtil.java
+++ b/src/main/java/com/devtraces/arterest/service/auth/util/TokenRedisUtil.java
@@ -2,6 +2,7 @@ package com.devtraces.arterest.service.auth.util;
 
 import static com.devtraces.arterest.common.jwt.JwtProvider.REFRESH_TOKEN_SUBJECT_PREFIX;
 
+import com.devtraces.arterest.common.exception.BaseException;
 import java.time.Duration;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,8 @@ public class TokenRedisUtil {
 	public boolean hasSameRefreshToken(long userId, String refreshToken) {
 		ValueOperations<String, String> values = redisTemplate.opsForValue();
 		String encodingRefreshToken = values.get(REFRESH_TOKEN_SUBJECT_PREFIX + userId);
+		if(encodingRefreshToken == null) throw BaseException.INVALID_TOKEN;
+
 		return passwordEncoder.matches(refreshToken, encodingRefreshToken);
 	}
 


### PR DESCRIPTION
## 📍 관련 이슈
- 기존에 로그아웃 후 토큰 재발급 시 500 에러 발생함.

## 📍 특이사항
- 기존에 로그아웃을 하면 redis 에서 해당 유저의 refresh token 이 제거되는데, 이후 토큰을 재발급하면 redis 에 접근했을 때 refresh token 을 발견하지 못해 500 에러가 발생함. 따라서 null 인 경우 예외처리를 하여 400 에러를 발생시킴.

## 📍 테스트
- [x] API Test
