### PR TITLE
회원탈퇴시 JWT 쿠키 제거 로직 추가

### DIFF
--- a/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
+++ b/src/main/java/com/devtraces/arterest/common/jwt/JwtProvider.java
@@ -92,10 +92,24 @@ public class JwtProvider {
 		return cookie;
 	}
 
+	public ResponseCookie deleteCookie(String token, String name) {
+
+		ResponseCookie cookie = ResponseCookie.from(name, token)
+			.httpOnly(true)
+			.path("/")
+			.maxAge(0)
+			.secure(true)
+			.sameSite(SameSite.NONE.attributeValue())
+			.build();
+
+		return cookie;
+	}
+
 	// JWT 토큰에서 인증 정보 조회
 	public Authentication getAuthentication(String accessToken) {
-		UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserId(accessToken));
-		return new UsernamePasswordAuthenticationToken(Long.parseLong(this.getUserId(accessToken)), "", userDetails.getAuthorities());
+		String userId = this.getUserId(accessToken);
+		UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+		return new UsernamePasswordAuthenticationToken(Long.parseLong(userId), "", userDetails.getAuthorities());
 	}
 
 	// JWT 토큰에서 회원 구별 정보 추출


### PR DESCRIPTION
## 📍 관련 이슈
- 회원탈퇴시 해당 userId 가 DB 에서 삭제되는데, 회원탈퇴 이후 다른 api 를 호출하면 JwtAuthenticationFilter 에서, 기존 쿠키의 access token 에서 userId 를 가져오려다 에러가 발생함.

## 📍 특이사항
- 유효한 쿠키를 걸러내는 방식과 회원탈퇴시 쿠키를 삭제하는 방법이 있는데, 걸러내는 방식은 다른 api 호출시에도 영향을 주게 되므로, 쿠키를 삭제하는 방식으로 구현함.

## 📍 테스트
- [x] API Test
